### PR TITLE
Add option to configure arguments passed to terminal emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ Otherwise, `handlr` will:
 
 On the upside, `Terminal=true` entries will now work outside of interactive terminals, unlike `xdg-utils`.
 
+### Terminal emulator compatibility
+`handlr` should work with pretty much any terminal emulator.
+
+However, some slight configuration may be necessary depending on what command line arguments your terminal emulator supports or required to directly run a command in it.
+
+If it uses/supports `-e` (i.e. `xterm`, `xfce4-terminal`, `foot`, etc.) then you do not need to do anything.
+
+If it requires something else, then set `term_exec_args` in `~/.config/handlr/handlr.toml` to the necessary arguments like so:
+
+```
+// Replace 'run' with whatever arguments you need 
+term_exec_args = 'run'
+```
+
+If it does not require any arguments or if its arguments are already included in its .desktop file, but it does not use `-e`, (i.e. `wezterm`, `kitty`, etc.) set `term_exec_args` to `''`.
+
+Feel free to open an issue or pull request if there's a better way to handle this.
+
 ## Setting multiple handlers
 
 1) Open `~/.config/handlr/handlr.toml` and set `enable_selector = true`. Optionally, you can also tweak the `selector` to your selector command (using e.g. rofi or dmenu).

--- a/handlr-regex/src/common/desktop_entry.rs
+++ b/handlr-regex/src/common/desktop_entry.rs
@@ -1,4 +1,4 @@
-use crate::{Error, ErrorKind, Result};
+use crate::{Config, Error, ErrorKind, Result};
 use aho_corasick::AhoCorasick;
 use mime::Mime;
 use std::{
@@ -94,10 +94,9 @@ impl DesktopEntry {
         // If the entry expects a terminal (emulator), but this process is not running in one, we
         // launch a new one.
         if self.terminal && !atty::is(atty::Stream::Stdout) {
-            exec = shlex::split(&crate::config::Config::terminal()?)
+            exec = shlex::split(&Config::terminal()?)
                 .unwrap()
                 .into_iter()
-                .chain(vec!["-e".to_owned()])
                 .chain(exec)
                 .collect();
         }


### PR DESCRIPTION
Adds config file option, `term_exec_args` to config file to configure what arguments are passed to terminal emulator when running `handlr get --json` for a terminal program when not in a terminal. Fixes #7