### PR TITLE
Allow empty associations

### DIFF
--- a/handlr-regex/src/common/ini.pest
+++ b/handlr-regex/src/common/ini.pest
@@ -6,7 +6,7 @@ section = { "[" ~ (section_char)+  ~ "]" }
 
 property = { name ~ "=" ~ value }
 name = { name_char+ }
-value = { value_char+ }
+value = { value_char* }
 
 comment = { "#" ~ name_char* }
 


### PR DESCRIPTION
The [spec for mimetypes.list](https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html#default) doesn't seem to forbid the value of an association/default application to be the empty string.

Either way, I think `handlr-regex` should be able to tolerate a `mimetypes.list` that has such lines. For example, with a `mimetypes.list` file like this:
```
[Default Applications]
text/plain=
```
launching the program results in a panic:
```shell
$ handlr
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { kind: ParseApps(Error { variant: ParsingError { positives: [value_char], negatives: [] }, location: Pos(34), line_col: Pos((2, 12)), path: None, line: "text/plain=␊", continued_line: None }) }', handlr-regex/src/apps/user.rs:16:65
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

So in this PR, we relax the parser to not require a value to be non-empty, which was the source of the error that was unwrapped with a panic. Then, when each line of the file is iterated over, the empty string will result in an empty `handlers` collection on https://github.com/Anomalocaridid/handlr-regex/blob/d06e76c675c2dbeb9d8bb7fdafe6f867f7b04549/handlr-regex/src/apps/user.rs#L173

This will mean the fact that the association value was the empty string is silently ignored.