### PR TITLE
Add subcommand to remove a handler

### DIFF
--- a/assets/completions/_handlr
+++ b/assets/completions/_handlr
@@ -22,6 +22,7 @@ _handlr_commands() {
       'launch:Launch the handler for specified extension/mime with optional arguments'
       'get:Get handler for this mime/extension'
       'add:Add a handler for given mime/extension; note that the first handler is the default'
+      'remove:Remove a given handler from a given mime/extension'
       'mime:Get the mimetype of a path/URL'
   )
   _describe -t handlr-commands "command" subcommands
@@ -42,7 +43,7 @@ _handlr_subcommand () {
           '1:types:_handlr_types' \
           '2:filename/path:_files'
       ;;
-    (set|add)
+    (set|add|remove)
       _arguments \
           '1:type:_handlr_types' \
           '2:desktop:_handlr_desktops'

--- a/assets/completions/handlr
+++ b/assets/completions/handlr
@@ -7,7 +7,7 @@ _handlr()
         COMPREPLY=($(compgen -W 'get help launch list open set unset mime' -- "$cur"))
     else
         case ${words[1]} in
-            set | add)
+            set | add | remove)
                 if ((cword == 2)); then
                     COMPREPLY=($(compgen -W '$(handlr autocomplete -m)' -- "$cur"))
                 elif ((cword == 3)); then

--- a/assets/completions/handlr.fish
+++ b/assets/completions/handlr.fish
@@ -1,10 +1,12 @@
 function __handlr_autocomplete
   function subcommands
-    set -l handlr_commands 'get help launch list open set unset mime'
+    set -l handlr_commands 'add get help launch list open set unset mime'
+    complete -f -c handlr -n "not __fish_seen_subcommand_from $handlr_commands" -a "add" -d "Add a handler for given mime/extension"
     complete -f -c handlr -n "not __fish_seen_subcommand_from $handlr_commands" -a "get" -d "Show handler for mime"
     complete -f -c handlr -n "not __fish_seen_subcommand_from $handlr_commands" -a "launch" -d "Launch given handler with path/args"
     complete -f -c handlr -n "not __fish_seen_subcommand_from $handlr_commands" -a "list" -d "Show handlers (default applications)"
     complete -f -c handlr -n "not __fish_seen_subcommand_from $handlr_commands" -a "open" -d "Open path/URL with default handler (like xdg-open)"
+    complete -f -c handlr -n "not __fish_seen_subcommand_from $handlr_commands" -a "remove" -d "Remove a given handler from a given mime/extension"
     complete -f -c handlr -n "not __fish_seen_subcommand_from $handlr_commands" -a "set" -d "Set handler for extension (e.g. pdf) or mime type"
     complete -f -c handlr -n "not __fish_seen_subcommand_from $handlr_commands" -a "unset" -d "Unset handler"
     complete -f -c handlr -n "not __fish_seen_subcommand_from $handlr_commands" -a "mime" -d "Get mimetype of path/URL"

--- a/assets/manual/man1/handlr-remove.1
+++ b/assets/manual/man1/handlr-remove.1
@@ -1,0 +1,23 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH handlr-remove 1  "handlr-remove " 
+.SH NAME
+handlr-regex\-remove - Remove a given handler from a given mime/extension
+.SH SYNOPSIS
+\fBhandlr remove\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> <\fIHANDLER\fR> 
+.SH DESCRIPTION
+Remove a given handler from a given mime/extension
+.PP
+Note that if a handler is not supplied,
+.PP
+Wildcards cannot be used unless removing handlers from mimetypes that already have wildcards.
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+<\fIMIME\fR>
+Mimetype to remove handler from
+.TP
+<\fIHANDLER\fR>
+Desktop file of handler program to remove

--- a/assets/manual/man1/handlr.1
+++ b/assets/manual/man1/handlr.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr 1  "handlr 0.7.1" 
+.TH handlr 1  "handlr 0.8.5" 
 .SH NAME
 handlr-regex - Fork of handlr with regex support
 .SH SYNOPSIS
@@ -43,7 +43,10 @@ Get handler for this mime/extension
 handlr\-add(1)
 Add a handler for given mime/extension
 .TP
+handlr\-remove(1)
+Remove a given handler from a given mime/extension
+.TP
 handlr\-mime(1)
 Get the mimetype of a given file/URL
 .SH VERSION
-v0.7.1
+v0.8.5

--- a/handlr-regex/src/apps/user.rs
+++ b/handlr-regex/src/apps/user.rs
@@ -36,9 +36,25 @@ impl MimeApps {
         self.default_apps.insert(mime, vec![handler].into());
     }
 
-    pub fn remove_handler(&mut self, mime: &Mime) -> Result<()> {
-        if let Some(_removed) = self.default_apps.remove(mime) {
+    pub fn unset_handler(&mut self, mime: &Mime) -> Result<()> {
+        if let Some(_unset) = self.default_apps.remove(mime) {
             self.save()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn remove_handler(
+        &mut self,
+        mime: Mime,
+        handler: Handler,
+    ) -> Result<()> {
+        let handler_list = self.default_apps.entry(mime).or_default();
+
+        if let Some(pos) = handler_list.iter().position(|x| *x == handler) {
+            if let Some(_removed) = handler_list.remove(pos) {
+                self.save()?
+            }
         }
 
         Ok(())

--- a/handlr-regex/src/cli.rs
+++ b/handlr-regex/src/cli.rs
@@ -128,6 +128,19 @@ pub enum Cmd {
         handler: Handler,
     },
 
+    /// Remove a given handler from a given mime/extension
+    ///
+    /// Note that if a handler is not supplied,
+    ///
+    /// Wildcards cannot be used unless removing handlers from mimetypes
+    /// that already have wildcards.
+    Remove {
+        /// Mimetype to remove handler from
+        mime: MimeOrExtension,
+        /// Desktop file of handler program to remove
+        handler: Handler,
+    },
+
     /// Get the mimetype of a given file/URL
     ///
     /// By default, output is in the form of a table that matches file paths/URLs to their mimetypes.
@@ -171,7 +184,7 @@ pub enum Cmd {
     /// Helper subcommand for autocompletion scripts; should be hidden
     ///
     /// This should not be visible in `handlr --help` output, autocompletion, or man pages.
-    /// If you see this there, please open an issue on Github.
+    /// If you see this there, please open an issue on GitHub.
     ///
     /// However it is fine if this shows up in the output of `handlr autocomplete --help`.
     Autocomplete {

--- a/handlr-regex/src/main.rs
+++ b/handlr-regex/src/main.rs
@@ -42,7 +42,10 @@ fn main() -> Result<()> {
                 apps.print(all)?;
             }
             Cmd::Unset { mime } => {
-                apps.remove_handler(&mime.0)?;
+                apps.unset_handler(&mime.0)?;
+            }
+            Cmd::Remove { mime, handler } => {
+                apps.remove_handler(mime.0, handler)?;
             }
             Cmd::Autocomplete {
                 desktop_files,


### PR DESCRIPTION
I added a subcomand, `handlr remove`, which remove a given handler from a given mimetype from mimeapps.list without removing the other handlers, like in `handlr unset`.

Addresses #34