### PR TITLE
Overhaul json and table output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,7 +478,9 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde",
+ "serde_json",
  "shlex",
+ "tabled",
  "thiserror",
  "url",
  "xdg",
@@ -843,6 +851,17 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "papergrid"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ad43c07024ef767f9160710b3a6773976194758c7919b17e63b863db0bdf7fb"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1250,6 +1269,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c998b0c8b921495196a48aabaf1901ff28be0760136e31604f7967b0792050e"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c138f99377e5d653a371cdad263615634cfc8467685dfe8e73e2b8e98f44b17"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,6 +1487,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,12 +42,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "ascii_table"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f0a58f3b1453981b910b603a4a7346be14fccd50f8edd7c954725a9210c24f"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,7 +459,6 @@ name = "handlr-regex"
 version = "0.9.0"
 dependencies = [
  "aho-corasick 0.7.20",
- "ascii_table",
  "clap",
  "confy",
  "freedesktop_entry_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,6 @@ dependencies = [
  "confy",
  "freedesktop_entry_parser",
  "itertools",
- "json",
  "mime",
  "mime-db",
  "once_cell",
@@ -644,12 +643,6 @@ checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "lazy_static"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ For more information:
 * [desktop entry field codes](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables)
 * [regex reference](https://docs.rs/regex/latest/regex/#syntax)
 
+## Smart table output
+
+Starting with v0.10.0, commands with table output (i.e. `handlr list` and `handlr mime`) switch to outputting tab-separated values when piped for use with commands like `cut`.
+
 ## Screenshots
 
 <table><tr><td>

--- a/assets/manual/man1/handlr-get.1
+++ b/assets/manual/man1/handlr-get.1
@@ -18,11 +18,11 @@ When using `\-\-json`, output is in the form:
 .PP
 {
 .PP
+"cmd": "helix"
+.PP
 "handler": "helix.desktop",
 .PP
 "name": "Helix",
-.PP
-"cmd": "helix"
 .PP
 }
 .PP

--- a/assets/manual/man1/handlr-list.1
+++ b/assets/manual/man1/handlr-list.1
@@ -4,17 +4,74 @@
 .SH NAME
 handlr-regex\-list - List default apps and the associated handlers
 .SH SYNOPSIS
-\fBhandlr list\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-a\fR|\fB\-\-all\fR] 
+\fBhandlr list\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-j\fR|\fB\-\-json\fR] [\fB\-a\fR|\fB\-\-all\fR] 
 .SH DESCRIPTION
 List default apps and the associated handlers
 .PP
 Output is formatted as a table with two columns. The left column shows mimetypes and the right column shows the handlers
 .PP
 Currently does not support regex handlers.
+.PP
+When using `\-\-json`, output will be in the form:
+.PP
+```json
+.PP
+[
+.PP
+{
+.PP
+"mime": "text/*",
+.PP
+"handlers": [
+.PP
+"Helix.desktop"
+.PP
+]
+.PP
+},
+.PP
+{
+.PP
+"mime": "x\-scheme\-handler/https",
+.PP
+"handlers": [
+.PP
+"firefox.desktop",
+.PP
+"nyxt.desktop"
+.PP
+]
+.PP
+},
+.PP
+]
+.PP
+```
+.PP
+When using `\-\-json` with `\-\-all`, output will be in the form
+.PP
+```json
+.PP
+{
+.PP
+"added_associations": [ ... ],
+.PP
+"default_apps": [ ... ],
+.PP
+"system_apps": [ ... ],
+.PP
+}
+.PP
+```
+.PP
+Where each top\-level key has an array with the same scheme as the normal `\-\-json` output
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help information
+.TP
+\fB\-j\fR, \fB\-\-json\fR
+Output handler info as json
 .TP
 \fB\-a\fR, \fB\-\-all\fR
 Expand wildcards in mimetypes and show global defaults

--- a/assets/manual/man1/handlr.1
+++ b/assets/manual/man1/handlr.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr 1  "handlr 0.8.5" 
+.TH handlr 1  "handlr 0.9.0" 
 .SH NAME
 handlr-regex - Fork of handlr with regex support
 .SH SYNOPSIS
@@ -49,4 +49,4 @@ Remove a given handler from a given mime/extension
 handlr\-mime(1)
 Get the mimetype of a given file/URL
 .SH VERSION
-v0.8.5
+v0.9.0

--- a/handlr-regex/Cargo.toml
+++ b/handlr-regex/Cargo.toml
@@ -15,7 +15,6 @@ url = "2.2.1"
 itertools = "0.10.0"
 shlex = "1.3.0"
 thiserror = "1.0.24"
-ascii_table = "3.0.2" # REMOVE WHEN DONE
 xdg = "2.2.0"
 mime = "0.3.16"
 mime-db = "1.3.0"

--- a/handlr-regex/Cargo.toml
+++ b/handlr-regex/Cargo.toml
@@ -13,7 +13,6 @@ pest_derive = "2.1.0"
 clap = { version = "3.0.0-beta.2", features = ["derive"] }
 url = "2.2.1"
 itertools = "0.10.0"
-json = "0.12.4" # REMOVE WHEN DONE
 shlex = "1.3.0"
 thiserror = "1.0.24"
 ascii_table = "3.0.2" # REMOVE WHEN DONE

--- a/handlr-regex/Cargo.toml
+++ b/handlr-regex/Cargo.toml
@@ -13,10 +13,10 @@ pest_derive = "2.1.0"
 clap = { version = "3.0.0-beta.2", features = ["derive"] }
 url = "2.2.1"
 itertools = "0.10.0"
-json = "0.12.4"
+json = "0.12.4" # REMOVE WHEN DONE
 shlex = "1.3.0"
 thiserror = "1.0.24"
-ascii_table = "3.0.2"
+ascii_table = "3.0.2" # REMOVE WHEN DONE
 xdg = "2.2.0"
 mime = "0.3.16"
 mime-db = "1.3.0"
@@ -27,6 +27,8 @@ freedesktop_entry_parser = "1.1.1"
 once_cell = "1.7.2"
 aho-corasick = "0.7.15"
 regex = "1"
+tabled = "0.15.0"
+serde_json = "1.0"
 
 [[bin]]
 name = "handlr"

--- a/handlr-regex/src/apps/user.rs
+++ b/handlr-regex/src/apps/user.rs
@@ -6,6 +6,7 @@ use crate::{
 use mime::Mime;
 use once_cell::sync::Lazy;
 use pest::Parser;
+
 use std::{
     collections::{HashMap, VecDeque},
     io::Read,
@@ -126,11 +127,11 @@ impl MimeApps {
             let entry = handler.get_entry()?;
             let cmd = entry.get_cmd(vec![])?;
 
-            (json::object! {
-                handler: handler.to_string(),
-                name: entry.name.as_str(),
-                cmd: cmd.0 + " " + &cmd.1.join(" "),
-            })
+            (serde_json::json!( {
+                "handler": handler.to_string(),
+                "name": entry.name.as_str(),
+                "cmd": cmd.0 + " " + &cmd.1.join(" "),
+            }))
             .to_string()
         } else {
             handler.to_string()

--- a/handlr-regex/src/cli.rs
+++ b/handlr-regex/src/cli.rs
@@ -20,7 +20,64 @@ pub enum Cmd {
     /// The left column shows mimetypes and the right column shows the handlers
     ///
     /// Currently does not support regex handlers.
+    ///
+    /// When using `--json`, output will be in the form:
+    ///
+    /// ```json
+    ///
+    /// [
+    ///
+    ///   {
+    ///
+    ///     "mime": "text/*",
+    ///
+    ///     "handlers": [
+    ///
+    ///       "Helix.desktop"
+    ///
+    ///      ]
+    ///
+    ///   },
+    ///
+    ///   {
+    ///
+    ///     "mime": "x-scheme-handler/https",
+    ///
+    ///     "handlers": [
+    ///
+    ///       "firefox.desktop",
+    ///
+    ///       "nyxt.desktop"
+    ///
+    ///     ]
+    ///
+    ///   },
+    ///
+    /// ]
+    ///
+    /// ```
+    ///
+    /// When using `--json` with `--all`, output will be in the form
+    ///
+    /// ```json
+    ///
+    /// {
+    ///
+    ///   "added_associations": [ ... ],   
+    ///
+    ///   "default_apps": [ ... ],
+    ///
+    ///   "system_apps": [ ... ],
+    ///
+    /// }
+    ///
+    /// ```
+    ///
+    /// Where each top-level key has an array with the same scheme as the normal `--json` output
     List {
+        #[clap(long)]
+        /// Output handler info as json
+        json: bool,
         #[clap(long, short)]
         /// Expand wildcards in mimetypes and show global defaults
         all: bool,
@@ -95,11 +152,11 @@ pub enum Cmd {
     ///
     /// {
     ///
+    ///   "cmd": "helix"
+    ///
     ///   "handler": "helix.desktop",
     ///
     ///   "name": "Helix",
-    ///
-    ///   "cmd": "helix"
     ///
     /// }
     ///

--- a/handlr-regex/src/common/mod.rs
+++ b/handlr-regex/src/common/mod.rs
@@ -3,9 +3,11 @@ mod desktop_entry;
 mod handler;
 mod mime_types;
 mod path;
+mod table;
 
 pub use self::db::autocomplete as db_autocomplete;
 pub use desktop_entry::{DesktopEntry, Mode as ExecMode};
 pub use handler::{GenericHandler, Handler};
 pub use mime_types::{MimeOrExtension, MimeType};
 pub use path::{mime_table, UserPath};
+pub use table::render_table;

--- a/handlr-regex/src/common/path.rs
+++ b/handlr-regex/src/common/path.rs
@@ -1,16 +1,12 @@
 use mime::Mime;
 use serde::Serialize;
-use tabled::{
-    settings::{Alignment, Padding, Style},
-    Table, Tabled,
-};
+use tabled::Tabled;
 use url::Url;
 
-use crate::{common::MimeType, Error, ErrorKind, Result};
+use crate::{common::MimeType, render_table, Error, ErrorKind, Result};
 use std::{
     convert::TryFrom,
     fmt::{Display, Formatter},
-    io::IsTerminal,
     path::PathBuf,
     str::FromStr,
 };
@@ -82,17 +78,8 @@ pub fn mime_table(paths: &[UserPath], output_json: bool) -> Result<()> {
 
     let table = if output_json {
         serde_json::to_string(&rows)?
-    } else if std::io::stdout().is_terminal() {
-        // If output is going to a terminal, print as a table
-        Table::new(&rows).with(Style::sharp()).to_string()
     } else {
-        // If output is being piped, print as tab-delimited text
-        let mut table = Table::new(&rows);
-        table
-            .with(Style::empty().vertical('\t'))
-            .with(Alignment::left())
-            .with(Padding::zero());
-        table.to_string()
+        render_table(&rows)
     };
 
     println!("{table}");

--- a/handlr-regex/src/common/table.rs
+++ b/handlr-regex/src/common/table.rs
@@ -1,0 +1,24 @@
+use std::io::IsTerminal;
+
+use tabled::{
+    settings::{themes::Colorization, Alignment, Color, Padding, Style},
+    Table, Tabled,
+};
+
+pub fn render_table<T: Tabled>(rows: &Vec<T>) -> String {
+    let mut table = Table::new(rows);
+
+    if std::io::stdout().is_terminal() {
+        // If output is going to a terminal, print as a table
+        table
+            .with(Style::sharp())
+            .with(Colorization::rows([Color::FG_WHITE, Color::BG_BLACK]))
+    } else {
+        // If output is being piped, print as tab-delimited text
+        table
+            .with(Style::empty().vertical('\t'))
+            .with(Alignment::left())
+            .with(Padding::zero())
+    }
+    .to_string()
+}

--- a/handlr-regex/src/error.rs
+++ b/handlr-regex/src/error.rs
@@ -45,6 +45,8 @@ pub enum ErrorKind {
     NoTerminal,
     #[error("Bad path: {0}")]
     BadPath(String),
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/handlr-regex/src/main.rs
+++ b/handlr-regex/src/main.rs
@@ -38,8 +38,8 @@ fn main() -> Result<()> {
             Cmd::Mime { paths, json } => {
                 mime_table(&paths, json)?;
             }
-            Cmd::List { all } => {
-                apps.print(all)?;
+            Cmd::List { all, json } => {
+                apps.print(all, json)?;
             }
             Cmd::Unset { mime } => {
                 apps.unset_handler(&mime.0)?;


### PR DESCRIPTION
Various changes related to json and table output:
- Add `--json` to `handlr list` (Solves #46)
- Replace `json` with `serde_json` to take advantage of the `Serialize` trait.
- Replace `ascii_table` with `tabled` to solve the issue with truncated table output mentioned in #46 and to take advantage of the `Tabled` trait.
- Tweak formatting of table output to help with legibility for larger outputs.
- If a subcommand with tabular output is being piped, format the table(s) as tab-separated values to add another option for using output.