### PR TITLE
Fix manpage json snippets and simplify manpage rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,21 +36,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -141,52 +178,59 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
- "once_cell",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clap_mangen"
-version = "0.1.11"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105180c05a72388d5f5e4e4f6c79eecb92497bda749fa8f963a16647c5d5377f"
+checksum = "e1dd95b5ebb5c1c54581dd6346f3ed6a79a3eef95dd372fc2ac13d535535300e"
 dependencies = [
  "clap",
  "roff",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "confy"
@@ -447,7 +491,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -481,12 +525,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -496,15 +534,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "http"
@@ -589,22 +618,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -831,12 +850,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "papergrid"
@@ -1207,9 +1220,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
@@ -1290,21 +1303,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "termcolor"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -1492,6 +1490,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,15 +1613,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/assets/manual/man1/handlr-add.1
+++ b/assets/manual/man1/handlr-add.1
@@ -1,8 +1,8 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr-add 1  "handlr-add " 
+.TH handlr-add 1  "add " 
 .SH NAME
-handlr-regex\-add - Add a handler for given mime/extension
+handlr\-add \- Add a handler for given mime/extension
 .SH SYNOPSIS
 \fBhandlr add\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> <\fIHANDLER\fR> 
 .SH DESCRIPTION
@@ -14,7 +14,7 @@ This subcommand adds secondary handlers that coexist with the default and does n
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help information
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 <\fIMIME\fR>
 Mimetype to add handler to

--- a/assets/manual/man1/handlr-get.1
+++ b/assets/manual/man1/handlr-get.1
@@ -1,41 +1,36 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr-get 1  "handlr-get " 
+.TH handlr-get 1  "get " 
 .SH NAME
-handlr-regex\-get - Get handler for this mime/extension
+handlr\-get \- Get handler for this mime/extension
 .SH SYNOPSIS
-\fBhandlr get\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-\-json\fR] <\fIMIME\fR> 
+\fBhandlr get\fR [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> 
 .SH DESCRIPTION
 Get handler for this mime/extension
 .PP
-If multiple handlers are set and `enable_selector` is set to true, you will be prompted to select one using `selector` from ~/.config/handlr/handlr.toml. Otherwise, only the default handler will be printed.
+If multiple handlers are set and `enable_selector` is set to true,
+you will be prompted to select one using `selector` from ~/.config/handlr/handlr.toml.
+Otherwise, only the default handler will be printed.
 .PP
 Note that regex handlers are not supported by this subcommand currently.
 .PP
 When using `\-\-json`, output is in the form:
 .PP
-```json
-.PP
 {
-.PP
-"cmd": "helix"
-.PP
-"handler": "helix.desktop",
-.PP
-"name": "Helix",
-.PP
+  "cmd": "helix",
+  "handler": "helix.desktop",
+  "name": "Helix"
 }
 .PP
-```
-.PP
-Note that when handlr is not being directly output to a terminal, and the handler is a terminal program, the "cmd" key in the json output will include the command of the `x\-scheme\-handler/terminal` handler.
+Note that when handlr is not being directly output to a terminal, and the handler is a terminal program,
+the "cmd" key in the json output will include the command of the `x\-scheme\-handler/terminal` handler.
 .SH OPTIONS
-.TP
-\fB\-h\fR, \fB\-\-help\fR
-Print help information
 .TP
 \fB\-\-json\fR
 Output handler info as json
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 <\fIMIME\fR>
 Mimetype to get the handler of

--- a/assets/manual/man1/handlr-launch.1
+++ b/assets/manual/man1/handlr-launch.1
@@ -1,8 +1,8 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr-launch 1  "handlr-launch " 
+.TH handlr-launch 1  "launch " 
 .SH NAME
-handlr-regex\-launch - Launch the handler for specified extension/mime with optional arguments
+handlr\-launch \- Launch the handler for specified extension/mime with optional arguments
 .SH SYNOPSIS
 \fBhandlr launch\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> [\fIARGS\fR] 
 .SH DESCRIPTION
@@ -14,7 +14,7 @@ If multiple handlers are set and `enable_selector` is set to true, you will be p
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help information
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 <\fIMIME\fR>
 Mimetype or file extension to launch the handler of

--- a/assets/manual/man1/handlr-list.1
+++ b/assets/manual/man1/handlr-list.1
@@ -1,77 +1,53 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr-list 1  "handlr-list " 
+.TH handlr-list 1  "list " 
 .SH NAME
-handlr-regex\-list - List default apps and the associated handlers
+handlr\-list \- List default apps and the associated handlers
 .SH SYNOPSIS
-\fBhandlr list\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-j\fR|\fB\-\-json\fR] [\fB\-a\fR|\fB\-\-all\fR] 
+\fBhandlr list\fR [\fB\-\-json\fR] [\fB\-a\fR|\fB\-\-all\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 List default apps and the associated handlers
 .PP
-Output is formatted as a table with two columns. The left column shows mimetypes and the right column shows the handlers
+Output is formatted as a table with two columns.
+The left column shows mimetypes and the right column shows the handlers
 .PP
 Currently does not support regex handlers.
 .PP
 When using `\-\-json`, output will be in the form:
 .PP
-```json
-.PP
 [
-.PP
-{
-.PP
-"mime": "text/*",
-.PP
-"handlers": [
-.PP
-"Helix.desktop"
-.PP
+  {
+    "mime": "text/*",
+    "handlers": [
+      "Helix.desktop"
+     ]
+  },
+  {
+    "mime": "x\-scheme\-handler/https",
+    "handlers": [
+      "firefox.desktop",
+      "nyxt.desktop"
+    ]
+  },
+  ...
 ]
-.PP
-},
-.PP
-{
-.PP
-"mime": "x\-scheme\-handler/https",
-.PP
-"handlers": [
-.PP
-"firefox.desktop",
-.PP
-"nyxt.desktop"
-.PP
-]
-.PP
-},
-.PP
-]
-.PP
-```
 .PP
 When using `\-\-json` with `\-\-all`, output will be in the form
 .PP
-```json
-.PP
 {
-.PP
-"added_associations": [ ... ],
-.PP
-"default_apps": [ ... ],
-.PP
-"system_apps": [ ... ],
-.PP
+  "added_associations": [ ... ],   
+  "default_apps": [ ... ],
+  "system_apps": [ ... ]
 }
-.PP
-```
 .PP
 Where each top\-level key has an array with the same scheme as the normal `\-\-json` output
 .SH OPTIONS
 .TP
-\fB\-h\fR, \fB\-\-help\fR
-Print help information
-.TP
-\fB\-j\fR, \fB\-\-json\fR
+\fB\-\-json\fR
 Output handler info as json
 .TP
 \fB\-a\fR, \fB\-\-all\fR
 Expand wildcards in mimetypes and show global defaults
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/assets/manual/man1/handlr-mime.1
+++ b/assets/manual/man1/handlr-mime.1
@@ -1,10 +1,10 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr-mime 1  "handlr-mime " 
+.TH handlr-mime 1  "mime " 
 .SH NAME
-handlr-regex\-mime - Get the mimetype of a given file/URL
+handlr\-mime \- Get the mimetype of a given file/URL
 .SH SYNOPSIS
-\fBhandlr mime\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-\-json\fR] [\fIPATHS\fR] 
+\fBhandlr mime\fR [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIPATHS\fR> 
 .SH DESCRIPTION
 Get the mimetype of a given file/URL
 .PP
@@ -12,38 +12,24 @@ By default, output is in the form of a table that matches file paths/URLs to the
 .PP
 When using `\-\-json`, output will be in the form:
 .PP
-```json
-.PP
 [
-.PP
-{
-.PP
-"path": "README.md"
-.PP
-"mime": "text/markdown"
-.PP
-},
-.PP
-{
-.PP
-"path": "https://duckduckgo.com/"
-.PP
-"mime": "x\-scheme\-handler/https"
-.PP
-}
-.PP
+  {
+    "path": "README.md"
+    "mime": "text/markdown"
+  },
+  {
+    "path": "https://duckduckgo.com/"
+    "mime": "x\-scheme\-handler/https"
+  },
 \&...
-.PP
 ]
-.PP
-```
 .SH OPTIONS
-.TP
-\fB\-h\fR, \fB\-\-help\fR
-Print help information
 .TP
 \fB\-\-json\fR
 Output mimetype info as json
 .TP
-[\fIPATHS\fR]
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+<\fIPATHS\fR>
 File paths/URLs to get the mimetype of

--- a/assets/manual/man1/handlr-open.1
+++ b/assets/manual/man1/handlr-open.1
@@ -1,8 +1,8 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr-open 1  "handlr-open " 
+.TH handlr-open 1  "open " 
 .SH NAME
-handlr-regex\-open - Open a path/URL with its default handler
+handlr\-open \- Open a path/URL with its default handler
 .SH SYNOPSIS
 \fBhandlr open\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIPATHS\fR> 
 .SH DESCRIPTION
@@ -14,7 +14,7 @@ If multiple handlers are set and `enable_selector` is set to true, you will be p
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help information
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 <\fIPATHS\fR>
 Paths/URLs to open

--- a/assets/manual/man1/handlr-remove.1
+++ b/assets/manual/man1/handlr-remove.1
@@ -1,8 +1,8 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr-remove 1  "handlr-remove " 
+.TH handlr-remove 1  "remove " 
 .SH NAME
-handlr-regex\-remove - Remove a given handler from a given mime/extension
+handlr\-remove \- Remove a given handler from a given mime/extension
 .SH SYNOPSIS
 \fBhandlr remove\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> <\fIHANDLER\fR> 
 .SH DESCRIPTION
@@ -14,7 +14,7 @@ Wildcards cannot be used unless removing handlers from mimetypes that already ha
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help information
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 <\fIMIME\fR>
 Mimetype to remove handler from

--- a/assets/manual/man1/handlr-set.1
+++ b/assets/manual/man1/handlr-set.1
@@ -1,8 +1,8 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr-set 1  "handlr-set " 
+.TH handlr-set 1  "set " 
 .SH NAME
-handlr-regex\-set - Set the default handler for mime/extension
+handlr\-set \- Set the default handler for mime/extension
 .SH SYNOPSIS
 \fBhandlr set\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> <\fIHANDLER\fR> 
 .SH DESCRIPTION
@@ -18,7 +18,7 @@ Currently does not support regex handlers.
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help information
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 <\fIMIME\fR>
 Mimetype or file extension to operate on

--- a/assets/manual/man1/handlr-unset.1
+++ b/assets/manual/man1/handlr-unset.1
@@ -1,8 +1,8 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH handlr-unset 1  "handlr-unset " 
+.TH handlr-unset 1  "unset " 
 .SH NAME
-handlr-regex\-unset - Unset the default handler for mime/extension
+handlr\-unset \- Unset the default handler for mime/extension
 .SH SYNOPSIS
 \fBhandlr unset\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> 
 .SH DESCRIPTION
@@ -16,7 +16,7 @@ Currently does not support regex handlers.
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help information
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 <\fIMIME\fR>
 Mimetype or file extension to unset the default handler of

--- a/assets/manual/man1/handlr.1
+++ b/assets/manual/man1/handlr.1
@@ -2,7 +2,7 @@
 .el .ds Aq '
 .TH handlr 1  "handlr 0.9.0" 
 .SH NAME
-handlr-regex - Fork of handlr with regex support
+handlr \- Fork of handlr with regex support
 .SH SYNOPSIS
 \fBhandlr\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
 .SH DESCRIPTION
@@ -16,10 +16,10 @@ Regular expression handlers inspired by mimeo at <https://xyne.dev/projects/mime
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help information
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 \fB\-V\fR, \fB\-\-version\fR
-Print version information
+Print version
 .SH SUBCOMMANDS
 .TP
 handlr\-list(1)

--- a/handlr-regex/Cargo.toml
+++ b/handlr-regex/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/Anomalocaridid/handlr-regex"
 [dependencies]
 pest = "2.1.3"
 pest_derive = "2.1.0"
-clap = { version = "3.0.0-beta.2", features = ["derive"] }
+clap = { version = "4.5.2", features = ["derive"] }
 url = "2.2.1"
 itertools = "0.10.0"
 shlex = "1.3.0"

--- a/handlr-regex/src/cli.rs
+++ b/handlr-regex/src/cli.rs
@@ -13,6 +13,7 @@ use clap::Parser;
 #[clap(disable_help_subcommand = true)]
 #[clap(version, about)]
 pub enum Cmd {
+    #[clap(verbatim_doc_comment)]
     /// List default apps and the associated handlers
     ///
     /// Output is formatted as a table with two columns.
@@ -22,55 +23,30 @@ pub enum Cmd {
     ///
     /// When using `--json`, output will be in the form:
     ///
-    /// ```json
-    ///
     /// [
-    ///
     ///   {
-    ///
     ///     "mime": "text/*",
-    ///
     ///     "handlers": [
-    ///
     ///       "Helix.desktop"
-    ///
     ///      ]
-    ///
     ///   },
-    ///
     ///   {
-    ///
     ///     "mime": "x-scheme-handler/https",
-    ///
     ///     "handlers": [
-    ///
     ///       "firefox.desktop",
-    ///
     ///       "nyxt.desktop"
-    ///
     ///     ]
-    ///
     ///   },
-    ///
+    ///   ...
     /// ]
-    ///
-    /// ```
     ///
     /// When using `--json` with `--all`, output will be in the form
     ///
-    /// ```json
-    ///
     /// {
-    ///
     ///   "added_associations": [ ... ],   
-    ///
     ///   "default_apps": [ ... ],
-    ///
-    ///   "system_apps": [ ... ],
-    ///
+    ///   "system_apps": [ ... ]
     /// }
-    ///
-    /// ```
     ///
     /// Where each top-level key has an array with the same scheme as the normal `--json` output
     List {
@@ -137,6 +113,7 @@ pub enum Cmd {
         args: Vec<UserPath>,
     },
 
+    #[clap(verbatim_doc_comment)]
     /// Get handler for this mime/extension
     ///
     /// If multiple handlers are set and `enable_selector` is set to true,
@@ -147,19 +124,11 @@ pub enum Cmd {
     ///
     /// When using `--json`, output is in the form:
     ///
-    /// ```json
-    ///
     /// {
-    ///
-    ///   "cmd": "helix"
-    ///
+    ///   "cmd": "helix",
     ///   "handler": "helix.desktop",
-    ///
-    ///   "name": "Helix",
-    ///
+    ///   "name": "Helix"
     /// }
-    ///
-    /// ```
     ///
     /// Note that when handlr is not being directly output to a terminal, and the handler is a terminal program,
     /// the "cmd" key in the json output will include the command of the `x-scheme-handler/terminal` handler.
@@ -197,43 +166,31 @@ pub enum Cmd {
         handler: Handler,
     },
 
+    #[clap(verbatim_doc_comment)]
     /// Get the mimetype of a given file/URL
     ///
     /// By default, output is in the form of a table that matches file paths/URLs to their mimetypes.
     ///
     /// When using `--json`, output will be in the form:
     ///
-    /// ```json
-    ///
     /// [
-    ///
     ///   {
-    ///
     ///     "path": "README.md"
-    ///
     ///     "mime": "text/markdown"
-    ///
     ///   },
-    ///
     ///   {
-    ///
     ///     "path": "https://duckduckgo.com/"
-    ///
     ///     "mime": "x-scheme-handler/https"
-    ///
-    ///   }
-    ///
+    ///   },
     /// ...
-    ///
     /// ]
-    ///
-    /// ```
     Mime {
+        #[clap(required = true)]
+        /// File paths/URLs to get the mimetype of
+        paths: Vec<UserPath>,
         #[clap(long)]
         /// Output mimetype info as json
         json: bool,
-        /// File paths/URLs to get the mimetype of
-        paths: Vec<UserPath>,
     },
 
     #[clap(hide = true)]

--- a/handlr-regex/src/cli.rs
+++ b/handlr-regex/src/cli.rs
@@ -10,7 +10,6 @@ use clap::Parser;
 /// Regular expression handlers inspired by mimeo at <https://xyne.dev/projects/mimeo/>
 #[deny(missing_docs)]
 #[derive(Parser)]
-#[clap(global_setting = clap::AppSettings::DeriveDisplayOrder)]
 #[clap(disable_help_subcommand = true)]
 #[clap(version, about)]
 pub enum Cmd {

--- a/handlr-regex/src/common/mime_types.rs
+++ b/handlr-regex/src/common/mime_types.rs
@@ -65,7 +65,7 @@ fn mime_to_option(db: &xdg_mime::SharedMimeInfo, mime: Mime) -> Option<Mime> {
 }
 
 // Mime derived from user input: extension(.pdf) or type like image/jpg
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MimeOrExtension(pub Mime);
 
 impl FromStr for MimeOrExtension {

--- a/handlr-regex/src/common/path.rs
+++ b/handlr-regex/src/common/path.rs
@@ -11,6 +11,7 @@ use std::{
     str::FromStr,
 };
 
+#[derive(Clone)]
 pub enum UserPath {
     Url(Url),
     File(PathBuf),

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 handlr-regex = { path = "../handlr-regex" }
-clap = { version = "3.1.9", features = ["derive"] }
-clap_mangen = "0.1"
+clap = { version = "4.5.2", features = ["derive"] }
+clap_mangen = "0.2.20"
 regex = "1"


### PR DESCRIPTION
Uses clap's `#[clap(verbatim_doc_comment)]` derive attribute so that json snippets do not get messed up by preprocessing.

Also updates clap to take advantage of fixes that simplify `cargo xtask mangen`'s implementation.

Resolves #15.