### PR TITLE
[DOC] Shadow xdg-open instead of xdg-utils-handlr usage (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,14 @@ Starting with v0.10.0, commands with table output (i.e. `handlr list` and `handl
 sudo pacman -S handlr-regex
 ```
 
-Optionally you can also install `xdg-utils-handlr` from the AUR to replace `xdg-open`:
+Optionally you can also use `handlr-regex` as a replacement for `xdg-open` by putting a shadowing script into `$HOME/.local/bin` directtory (or any other `$PATH` directory). Use the following shell snippet as an example:
 
 ```sh
-paru -S xdg-utils-handlr
+echo "#!/bin/sh
+
+handlr open \"\$@\"
+" > $HOME/.local/bin/xdg-open
+chmod +x $HOME/.local/bin/xdg-open
 ```
 
 ### Rust/Cargo

--- a/README.md
+++ b/README.md
@@ -141,11 +141,9 @@ sudo pacman -S handlr-regex
 Optionally, you can also use `handlr-regex` as a replacement for `xdg-open` by shadowing it with a script in `$HOME/.local/bin/` (or any other user-scoped `$PATH` directory). Use the following script as an example:
 
 ```sh
-echo "#!/bin/sh
+#!/bin/sh
 
 handlr open \"\$@\"
-" > $HOME/.local/bin/xdg-open
-chmod +x $HOME/.local/bin/xdg-open
 ```
 
 ### Rust/Cargo

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Optionally, you can also use `handlr-regex` as a replacement for `xdg-open` by s
 ```sh
 #!/bin/sh
 
-handlr open \"\$@\"
+handlr open "$@"
 ```
 
 ### Rust/Cargo

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Starting with v0.10.0, commands with table output (i.e. `handlr list` and `handl
 sudo pacman -S handlr-regex
 ```
 
-Optionally you can also use `handlr-regex` as a replacement for `xdg-open` by putting a shadowing script into `$HOME/.local/bin` directtory (or any other `$PATH` directory). Use the following shell snippet as an example:
+Optionally, you can also use `handlr-regex` as a replacement for `xdg-open` by shadowing it with a script in `$HOME/.local/bin/` (or any other user-scoped `$PATH` directory). Use the following script as an example:
 
 ```sh
 echo "#!/bin/sh


### PR DESCRIPTION
Documentation change that I've mentioned in #53