### PR TITLE
Update Cargo.lock: fix build on loongarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libredox"


### PR DESCRIPTION
Update libc to v0.2.155 to support loongarch64.
Release notes: https://github.com/rust-lang/libc/releases.