### PR TITLE
fix: properly detect html files with no html tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,12 +84,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,7 +397,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9c27b72f19a99a895f8ca89e2d26e4ef31013376e56fdafef697627306c3e4"
 dependencies = [
- "nom 7.1.3",
+ "nom",
  "thiserror",
 ]
 
@@ -663,19 +657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,17 +750,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -1211,12 +1181,6 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1770,14 +1734,14 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xdg-mime"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bf7b69bb50588d70a36e467be29d3df3e8c32580276d62eded9738c1a797aa"
+checksum = "58d325d0ca93fb1984a56eb926f019acfc67bd2ec559b0dbf09cafcc92e81ec9"
 dependencies = [
  "dirs-next",
  "glob",
  "mime",
- "nom 5.1.3",
+ "nom",
  "unicase",
 ]
 

--- a/handlr-regex/Cargo.toml
+++ b/handlr-regex/Cargo.toml
@@ -21,7 +21,7 @@ mime = "0.3.16"
 mime-db = "1.3.0"
 confy = "0.4.0"
 serde = { version = "1.0.125", features = ["derive"] }
-xdg-mime = "0.3.3"
+xdg-mime = "0.4.0"
 freedesktop_entry_parser = "1.1.1"
 once_cell = "1.7.2"
 aho-corasick = "0.7.15"

--- a/handlr-regex/src/common/mime_types.rs
+++ b/handlr-regex/src/common/mime_types.rs
@@ -129,6 +129,14 @@ mod tests {
             MimeType::try_from(Path::new("./tests/empty.txt"))?.0,
             "text/plain"
         );
+        assert_eq!(
+            MimeType::try_from(Path::new("./tests/p.html"))?.0,
+            "text/html"
+        );
+        assert_eq!(
+            MimeType::try_from(Path::new("./tests/no_html_tags.html"))?.0,
+            "text/html"
+        );
 
         Ok(())
     }

--- a/handlr-regex/tests/no_html_tags.html
+++ b/handlr-regex/tests/no_html_tags.html
@@ -1,0 +1,1 @@
+<p> Hello World! <a href='https://google.com'></a> </p>


### PR DESCRIPTION
Updates `xdg-mime` to 0.4.0 to fix bug with improper file type detection and adds regression tests.

Closes #56