### PR TITLE
feat: add flags to override the selector options in the config file

### DIFF
--- a/assets/manual/man1/handlr-get.1
+++ b/assets/manual/man1/handlr-get.1
@@ -4,7 +4,7 @@
 .SH NAME
 handlr\-get \- Get handler for this mime/extension
 .SH SYNOPSIS
-\fBhandlr get\fR [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> 
+\fBhandlr get\fR [\fB\-\-json\fR] [\fB\-s\fR|\fB\-\-selector\fR] [\fB\-e\fR|\fB\-\-enable\-selector\fR] [\fB\-d\fR|\fB\-\-disable\-selector\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> 
 .SH DESCRIPTION
 Get handler for this mime/extension
 .PP
@@ -28,6 +28,15 @@ the "cmd" key in the json output will include the command of the `x\-scheme\-han
 .TP
 \fB\-\-json\fR
 Output handler info as json
+.TP
+\fB\-s\fR, \fB\-\-selector\fR=\fISELECTOR\fR
+Override the configured selector command
+.TP
+\fB\-e\fR, \fB\-\-enable\-selector\fR
+Enable selector, overrides `enable_selector`
+.TP
+\fB\-d\fR, \fB\-\-disable\-selector\fR
+Disable selector, overrides `enable_selector`
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/assets/manual/man1/handlr-launch.1
+++ b/assets/manual/man1/handlr-launch.1
@@ -4,7 +4,7 @@
 .SH NAME
 handlr\-launch \- Launch the handler for specified extension/mime with optional arguments
 .SH SYNOPSIS
-\fBhandlr launch\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> [\fIARGS\fR] 
+\fBhandlr launch\fR [\fB\-s\fR|\fB\-\-selector\fR] [\fB\-e\fR|\fB\-\-enable\-selector\fR] [\fB\-d\fR|\fB\-\-disable\-selector\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIMIME\fR> [\fIARGS\fR] 
 .SH DESCRIPTION
 Launch the handler for specified extension/mime with optional arguments
 .PP
@@ -12,6 +12,15 @@ Only supports wildcards for mimetypes for handlers that have been set or added w
 .PP
 If multiple handlers are set and `enable_selector` is set to true, you will be prompted to select one using `selector` from ~/.config/handlr/handlr.toml. Otherwise, the default handler will be opened.
 .SH OPTIONS
+.TP
+\fB\-s\fR, \fB\-\-selector\fR=\fISELECTOR\fR
+Override the configured selector command
+.TP
+\fB\-e\fR, \fB\-\-enable\-selector\fR
+Enable selector, overrides `enable_selector`
+.TP
+\fB\-d\fR, \fB\-\-disable\-selector\fR
+Disable selector, overrides `enable_selector`
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/assets/manual/man1/handlr-open.1
+++ b/assets/manual/man1/handlr-open.1
@@ -4,7 +4,7 @@
 .SH NAME
 handlr\-open \- Open a path/URL with its default handler
 .SH SYNOPSIS
-\fBhandlr open\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIPATHS\fR> 
+\fBhandlr open\fR [\fB\-s\fR|\fB\-\-selector\fR] [\fB\-e\fR|\fB\-\-enable\-selector\fR] [\fB\-d\fR|\fB\-\-disable\-selector\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIPATHS\fR> 
 .SH DESCRIPTION
 Open a path/URL with its default handler
 .PP
@@ -12,6 +12,15 @@ Unlike xdg\-open and similar resource openers, multiple paths/URLs may be suppli
 .PP
 If multiple handlers are set and `enable_selector` is set to true, you will be prompted to select one using `selector` from ~/.config/handlr/handlr.toml. Otherwise, the default handler will be opened.
 .SH OPTIONS
+.TP
+\fB\-s\fR, \fB\-\-selector\fR=\fISELECTOR\fR
+Override the configured selector command
+.TP
+\fB\-e\fR, \fB\-\-enable\-selector\fR
+Enable selector, overrides `enable_selector`
+.TP
+\fB\-d\fR, \fB\-\-disable\-selector\fR
+Disable selector, overrides `enable_selector`
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/handlr-regex/src/apps/user.rs
+++ b/handlr-regex/src/apps/user.rs
@@ -102,20 +102,20 @@ impl MimeApps {
     /// Get the handler associated with a given mime
     pub fn get_handler(
         &self,
-        config: &Config,
         system_apps: &SystemApps,
         mime: &Mime,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<DesktopHandler> {
-        match self.get_handler_from_user(config, mime, enable_selector) {
+        match self.get_handler_from_user(mime, selector, enable_selector) {
             Err(e) if matches!(*e.kind, ErrorKind::Cancelled) => Err(e),
             h => h
                 .or_else(|_| {
                     let wildcard =
                         Mime::from_str(&format!("{}/*", mime.type_()))?;
                     self.get_handler_from_user(
-                        config,
                         &wildcard,
+                        selector,
                         enable_selector,
                     )
                 })
@@ -131,15 +131,16 @@ impl MimeApps {
         config: &Config,
         system_apps: &SystemApps,
         path: &UserPath,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<Handler> {
         Ok(if let Ok(handler) = config.get_regex_handler(path) {
             handler.into()
         } else {
             self.get_handler(
-                config,
                 system_apps,
                 &path.get_mime()?,
+                selector,
                 enable_selector,
             )?
             .into()
@@ -149,8 +150,8 @@ impl MimeApps {
     /// Get the handler associated with a given mime from mimeapps.list's default apps
     fn get_handler_from_user(
         &self,
-        config: &Config,
         mime: &Mime,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<DesktopHandler> {
         let error = Error::from(ErrorKind::NotFound(mime.to_string()));
@@ -163,7 +164,7 @@ impl MimeApps {
 
                 let handler = {
                     let name =
-                        config.select(handlers.iter().map(|h| h.1.clone()))?;
+                        select(selector, handlers.iter().map(|h| h.1.clone()))?;
 
                     handlers
                         .into_iter()
@@ -202,10 +203,11 @@ impl MimeApps {
         system_apps: &SystemApps,
         mime: &Mime,
         output_json: bool,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<()> {
         let handler =
-            self.get_handler(config, system_apps, mime, enable_selector)?;
+            self.get_handler(system_apps, mime, selector, enable_selector)?;
         let output = if output_json {
             let entry = handler.get_entry()?;
             let cmd = entry.get_cmd(
@@ -213,6 +215,7 @@ impl MimeApps {
                 self,
                 system_apps,
                 vec![],
+                selector,
                 enable_selector,
             )?;
 
@@ -309,6 +312,7 @@ impl MimeApps {
         config: &Config,
         system_apps: &SystemApps,
         paths: &[UserPath],
+        selector: &str,
         enable_selector: bool,
     ) -> Result<()> {
         let mut handlers: HashMap<Handler, Vec<String>> = HashMap::new();
@@ -319,6 +323,7 @@ impl MimeApps {
                     config,
                     system_apps,
                     path,
+                    selector,
                     enable_selector,
                 )?)
                 .or_default()
@@ -326,7 +331,14 @@ impl MimeApps {
         }
 
         for (handler, paths) in handlers.into_iter() {
-            handler.open(config, self, system_apps, paths, enable_selector)?;
+            handler.open(
+                config,
+                self,
+                system_apps,
+                paths,
+                selector,
+                enable_selector,
+            )?;
         }
 
         Ok(())
@@ -339,14 +351,16 @@ impl MimeApps {
         system_apps: &SystemApps,
         mime: &Mime,
         args: Vec<UserPath>,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<()> {
-        self.get_handler(config, system_apps, mime, enable_selector)?
+        self.get_handler(system_apps, mime, selector, enable_selector)?
             .launch(
                 config,
                 self,
                 system_apps,
                 args.into_iter().map(|a| a.to_string()).collect(),
+                selector,
                 enable_selector,
             )
     }
@@ -413,6 +427,51 @@ impl MimeAppsTable {
     }
 }
 
+/// Run given selector command
+fn select<O: Iterator<Item = String>>(
+    selector: &str,
+    mut opts: O,
+) -> Result<String> {
+    use std::{
+        io::prelude::*,
+        process::{Command, Stdio},
+    };
+
+    let process = {
+        let mut split = shlex::split(selector).ok_or_else(|| {
+            Error::from(ErrorKind::BadCmd(selector.to_string()))
+        })?;
+        let (cmd, args) = (split.remove(0), split);
+        Command::new(cmd)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?
+    };
+
+    let output = {
+        process
+            .stdin
+            .ok_or_else(|| ErrorKind::Selector(selector.to_string()))?
+            .write_all(opts.join("\n").as_bytes())?;
+
+        let mut output = String::with_capacity(24);
+
+        process
+            .stdout
+            .ok_or_else(|| ErrorKind::Selector(selector.to_string()))?
+            .read_to_string(&mut output)?;
+
+        output.trim_end().to_owned()
+    };
+
+    if output.is_empty() {
+        Err(Error::from(ErrorKind::Cancelled))
+    } else {
+        Ok(output)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -429,15 +488,14 @@ mod tests {
             &DesktopHandler::assume_valid("brave.desktop".into()),
         );
 
-        let config = Config::default();
         let system_apps = SystemApps::default();
 
         assert_eq!(
             user_apps
                 .get_handler(
-                    &config,
                     &system_apps,
                     &Mime::from_str("video/mp4")?,
+                    "",
                     false
                 )?
                 .to_string(),
@@ -446,9 +504,9 @@ mod tests {
         assert_eq!(
             user_apps
                 .get_handler(
-                    &config,
                     &system_apps,
                     &Mime::from_str("video/asdf")?,
+                    "",
                     false
                 )?
                 .to_string(),
@@ -458,9 +516,9 @@ mod tests {
         assert_eq!(
             user_apps
                 .get_handler(
-                    &config,
                     &system_apps,
                     &Mime::from_str("video/webm")?,
+                    "",
                     false
                 )?
                 .to_string(),

--- a/handlr-regex/src/cli.rs
+++ b/handlr-regex/src/cli.rs
@@ -70,6 +70,9 @@ pub enum Cmd {
         /// Paths/URLs to open
         paths: Vec<UserPath>,
         #[clap(long, short)]
+        /// Override the configured selector command
+        selector: Option<String>,
+        #[clap(long, short)]
         /// Enable selector, overrides `enable_selector`
         enable_selector: bool,
         #[clap(long, short)]
@@ -119,6 +122,9 @@ pub enum Cmd {
         /// Arguments to pass to handler program
         args: Vec<UserPath>,
         #[clap(long, short)]
+        /// Override the configured selector command
+        selector: Option<String>,
+        #[clap(long, short)]
         /// Enable selector, overrides `enable_selector`
         enable_selector: bool,
         #[clap(long, short)]
@@ -152,6 +158,9 @@ pub enum Cmd {
         json: bool,
         /// Mimetype to get the handler of
         mime: MimeOrExtension,
+        #[clap(long, short)]
+        /// Override the configured selector command
+        selector: Option<String>,
         #[clap(long, short)]
         /// Enable selector, overrides `enable_selector`
         enable_selector: bool,

--- a/handlr-regex/src/cli.rs
+++ b/handlr-regex/src/cli.rs
@@ -69,6 +69,13 @@ pub enum Cmd {
         #[clap(required = true)]
         /// Paths/URLs to open
         paths: Vec<UserPath>,
+        #[clap(long, short)]
+        /// Enable selector, overrides `enable_selector`
+        enable_selector: bool,
+        #[clap(long, short)]
+        #[clap(overrides_with = "enable_selector")]
+        /// Disable selector, overrides `enable_selector`
+        disable_selector: bool,
     },
 
     /// Set the default handler for mime/extension
@@ -111,6 +118,13 @@ pub enum Cmd {
         mime: MimeOrExtension,
         /// Arguments to pass to handler program
         args: Vec<UserPath>,
+        #[clap(long, short)]
+        /// Enable selector, overrides `enable_selector`
+        enable_selector: bool,
+        #[clap(long, short)]
+        #[clap(overrides_with = "enable_selector")]
+        /// Disable selector, overrides `enable_selector`
+        disable_selector: bool,
     },
 
     #[clap(verbatim_doc_comment)]
@@ -138,6 +152,13 @@ pub enum Cmd {
         json: bool,
         /// Mimetype to get the handler of
         mime: MimeOrExtension,
+        #[clap(long, short)]
+        /// Enable selector, overrides `enable_selector`
+        enable_selector: bool,
+        #[clap(long, short)]
+        #[clap(overrides_with = "enable_selector")]
+        /// Disable selector, overrides `enable_selector`
+        disable_selector: bool,
     },
 
     /// Add a handler for given mime/extension

--- a/handlr-regex/src/common/desktop_entry.rs
+++ b/handlr-regex/src/common/desktop_entry.rs
@@ -50,6 +50,7 @@ impl DesktopEntry {
         system_apps: &SystemApps,
         mode: Mode,
         arguments: Vec<String>,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<()> {
         let supports_multiple =
@@ -60,6 +61,7 @@ impl DesktopEntry {
                 mime_apps,
                 system_apps,
                 vec![],
+                selector,
                 enable_selector,
             )?
         } else if supports_multiple || mode == Mode::Launch {
@@ -68,6 +70,7 @@ impl DesktopEntry {
                 mime_apps,
                 system_apps,
                 arguments,
+                selector,
                 enable_selector,
             )?;
         } else {
@@ -77,6 +80,7 @@ impl DesktopEntry {
                     mime_apps,
                     system_apps,
                     vec![arg],
+                    selector,
                     enable_selector,
                 )?;
             }
@@ -92,6 +96,7 @@ impl DesktopEntry {
         mime_apps: &mut MimeApps,
         system_apps: &SystemApps,
         args: Vec<String>,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<()> {
         let mut cmd = {
@@ -100,6 +105,7 @@ impl DesktopEntry {
                 mime_apps,
                 system_apps,
                 args,
+                selector,
                 enable_selector,
             )?;
             let mut cmd = Command::new(cmd);
@@ -123,6 +129,7 @@ impl DesktopEntry {
         mime_apps: &mut MimeApps,
         system_apps: &SystemApps,
         args: Vec<String>,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<(String, Vec<String>)> {
         let special =
@@ -165,8 +172,12 @@ impl DesktopEntry {
         // If the entry expects a terminal (emulator), but this process is not running in one, we
         // launch a new one.
         if self.terminal && !std::io::stdout().is_terminal() {
-            let term_cmd =
-                config.terminal(mime_apps, system_apps, enable_selector)?;
+            let term_cmd = config.terminal(
+                mime_apps,
+                system_apps,
+                selector,
+                enable_selector,
+            )?;
             exec = shlex::split(&term_cmd)
                 .ok_or_else(|| Error::from(ErrorKind::BadCmd(term_cmd)))?
                 .into_iter()

--- a/handlr-regex/src/common/desktop_entry.rs
+++ b/handlr-regex/src/common/desktop_entry.rs
@@ -50,16 +50,35 @@ impl DesktopEntry {
         system_apps: &SystemApps,
         mode: Mode,
         arguments: Vec<String>,
+        enable_selector: bool,
     ) -> Result<()> {
         let supports_multiple =
             self.exec.contains("%F") || self.exec.contains("%U");
         if arguments.is_empty() {
-            self.exec_inner(config, mime_apps, system_apps, vec![])?
+            self.exec_inner(
+                config,
+                mime_apps,
+                system_apps,
+                vec![],
+                enable_selector,
+            )?
         } else if supports_multiple || mode == Mode::Launch {
-            self.exec_inner(config, mime_apps, system_apps, arguments)?;
+            self.exec_inner(
+                config,
+                mime_apps,
+                system_apps,
+                arguments,
+                enable_selector,
+            )?;
         } else {
             for arg in arguments {
-                self.exec_inner(config, mime_apps, system_apps, vec![arg])?;
+                self.exec_inner(
+                    config,
+                    mime_apps,
+                    system_apps,
+                    vec![arg],
+                    enable_selector,
+                )?;
             }
         };
 
@@ -73,10 +92,16 @@ impl DesktopEntry {
         mime_apps: &mut MimeApps,
         system_apps: &SystemApps,
         args: Vec<String>,
+        enable_selector: bool,
     ) -> Result<()> {
         let mut cmd = {
-            let (cmd, args) =
-                self.get_cmd(config, mime_apps, system_apps, args)?;
+            let (cmd, args) = self.get_cmd(
+                config,
+                mime_apps,
+                system_apps,
+                args,
+                enable_selector,
+            )?;
             let mut cmd = Command::new(cmd);
             cmd.args(args);
             cmd
@@ -98,6 +123,7 @@ impl DesktopEntry {
         mime_apps: &mut MimeApps,
         system_apps: &SystemApps,
         args: Vec<String>,
+        enable_selector: bool,
     ) -> Result<(String, Vec<String>)> {
         let special =
             AhoCorasick::new_auto_configured(&["%f", "%F", "%u", "%U"]);
@@ -139,7 +165,8 @@ impl DesktopEntry {
         // If the entry expects a terminal (emulator), but this process is not running in one, we
         // launch a new one.
         if self.terminal && !std::io::stdout().is_terminal() {
-            let term_cmd = config.terminal(mime_apps, system_apps)?;
+            let term_cmd =
+                config.terminal(mime_apps, system_apps, enable_selector)?;
             exec = shlex::split(&term_cmd)
                 .ok_or_else(|| Error::from(ErrorKind::BadCmd(term_cmd)))?
                 .into_iter()

--- a/handlr-regex/src/common/handler.rs
+++ b/handlr-regex/src/common/handler.rs
@@ -36,6 +36,7 @@ pub trait Handleable {
         mime_apps: &mut MimeApps,
         system_apps: &SystemApps,
         args: Vec<String>,
+        enable_selector: bool,
     ) -> Result<()> {
         self.get_entry()?.exec(
             config,
@@ -43,6 +44,7 @@ pub trait Handleable {
             system_apps,
             ExecMode::Open,
             args,
+            enable_selector,
         )
     }
 }
@@ -98,6 +100,7 @@ impl DesktopHandler {
         mime_apps: &mut MimeApps,
         system_apps: &SystemApps,
         args: Vec<String>,
+        enable_selector: bool,
     ) -> Result<()> {
         self.get_entry()?.exec(
             config,
@@ -105,6 +108,7 @@ impl DesktopHandler {
             system_apps,
             ExecMode::Launch,
             args,
+            enable_selector,
         )
     }
 }

--- a/handlr-regex/src/common/handler.rs
+++ b/handlr-regex/src/common/handler.rs
@@ -36,6 +36,7 @@ pub trait Handleable {
         mime_apps: &mut MimeApps,
         system_apps: &SystemApps,
         args: Vec<String>,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<()> {
         self.get_entry()?.exec(
@@ -44,6 +45,7 @@ pub trait Handleable {
             system_apps,
             ExecMode::Open,
             args,
+            selector,
             enable_selector,
         )
     }
@@ -100,6 +102,7 @@ impl DesktopHandler {
         mime_apps: &mut MimeApps,
         system_apps: &SystemApps,
         args: Vec<String>,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<()> {
         self.get_entry()?.exec(
@@ -108,6 +111,7 @@ impl DesktopHandler {
             system_apps,
             ExecMode::Launch,
             args,
+            selector,
             enable_selector,
         )
     }

--- a/handlr-regex/src/config.rs
+++ b/handlr-regex/src/config.rs
@@ -45,12 +45,14 @@ impl Config {
         &self,
         mime_apps: &mut MimeApps,
         system_apps: &SystemApps,
+        enable_selector: bool,
     ) -> Result<String> {
         let terminal_entry = mime_apps
             .get_handler(
                 self,
                 system_apps,
                 &Mime::from_str("x-scheme-handler/terminal")?,
+                enable_selector,
             )
             .ok()
             .and_then(|h| h.get_entry().ok());
@@ -138,5 +140,14 @@ impl Config {
         } else {
             Ok(output)
         }
+    }
+
+    /// Determine whether or not the selector should be enabled
+    pub fn use_selector(
+        &self,
+        enable_selector: bool,
+        disable_selector: bool,
+    ) -> bool {
+        (self.enable_selector || enable_selector) && !disable_selector
     }
 }

--- a/handlr-regex/src/config.rs
+++ b/handlr-regex/src/config.rs
@@ -41,17 +41,20 @@ impl Config {
         self.handlers.get_handler(path)
     }
 
+    /// Get the command for the x-scheme-handler/terminal handler if one is set.
+    /// Otherwise, finds a terminal emulator program, sets it as the handler, and makes a notification.
     pub fn terminal(
         &self,
         mime_apps: &mut MimeApps,
         system_apps: &SystemApps,
+        selector: &str,
         enable_selector: bool,
     ) -> Result<String> {
         let terminal_entry = mime_apps
             .get_handler(
-                self,
                 system_apps,
                 &Mime::from_str("x-scheme-handler/terminal")?,
+                selector,
                 enable_selector,
             )
             .ok()
@@ -93,53 +96,10 @@ impl Config {
             })
             .ok_or(Error::from(ErrorKind::NoTerminal))
     }
+
+    /// Load ~/.config/handlr/handlr.toml
     pub fn load() -> Result<Self> {
         Ok(confy::load("handlr")?)
-    }
-
-    pub fn select<O: Iterator<Item = String>>(
-        &self,
-        mut opts: O,
-    ) -> Result<String> {
-        use itertools::Itertools;
-        use std::{
-            io::prelude::*,
-            process::{Command, Stdio},
-        };
-
-        let process = {
-            let mut split = shlex::split(&self.selector).ok_or_else(|| {
-                Error::from(ErrorKind::BadCmd(self.selector.clone()))
-            })?;
-            let (cmd, args) = (split.remove(0), split);
-            Command::new(cmd)
-                .args(args)
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()?
-        };
-
-        let output = {
-            process
-                .stdin
-                .ok_or_else(|| ErrorKind::Selector(self.selector.clone()))?
-                .write_all(opts.join("\n").as_bytes())?;
-
-            let mut output = String::with_capacity(24);
-
-            process
-                .stdout
-                .ok_or_else(|| ErrorKind::Selector(self.selector.clone()))?
-                .read_to_string(&mut output)?;
-
-            output.trim_end().to_owned()
-        };
-
-        if output.is_empty() {
-            Err(Error::from(ErrorKind::Cancelled))
-        } else {
-            Ok(output)
-        }
     }
 
     /// Determine whether or not the selector should be enabled

--- a/handlr-regex/src/main.rs
+++ b/handlr-regex/src/main.rs
@@ -23,15 +23,44 @@ fn main() -> Result<()> {
                 mime_apps.add_handler(&mime, &handler);
                 mime_apps.save()?;
             }
-            Cmd::Launch { mime, args } => {
-                mime_apps.launch_handler(&config, &system_apps, &mime, args)?;
+            Cmd::Launch {
+                mime,
+                args,
+                enable_selector,
+                disable_selector,
+            } => {
+                mime_apps.launch_handler(
+                    &config,
+                    &system_apps,
+                    &mime,
+                    args,
+                    config.use_selector(enable_selector, disable_selector),
+                )?;
             }
-            Cmd::Get { mime, json } => {
-                mime_apps.show_handler(&config, &system_apps, &mime, json)?;
+            Cmd::Get {
+                mime,
+                json,
+                enable_selector,
+                disable_selector,
+            } => {
+                mime_apps.show_handler(
+                    &config,
+                    &system_apps,
+                    &mime,
+                    json,
+                    config.use_selector(enable_selector, disable_selector),
+                )?;
             }
-            Cmd::Open { paths } => {
-                mime_apps.open_paths(&config, &system_apps, &paths)?
-            }
+            Cmd::Open {
+                paths,
+                enable_selector,
+                disable_selector,
+            } => mime_apps.open_paths(
+                &config,
+                &system_apps,
+                &paths,
+                config.use_selector(enable_selector, disable_selector),
+            )?,
             Cmd::Mime { paths, json } => {
                 mime_table(&paths, json)?;
             }

--- a/handlr-regex/src/main.rs
+++ b/handlr-regex/src/main.rs
@@ -26,6 +26,7 @@ fn main() -> Result<()> {
             Cmd::Launch {
                 mime,
                 args,
+                selector,
                 enable_selector,
                 disable_selector,
             } => {
@@ -34,12 +35,14 @@ fn main() -> Result<()> {
                     &system_apps,
                     &mime,
                     args,
+                    &selector.unwrap_or(config.selector.clone()),
                     config.use_selector(enable_selector, disable_selector),
                 )?;
             }
             Cmd::Get {
                 mime,
                 json,
+                selector,
                 enable_selector,
                 disable_selector,
             } => {
@@ -48,17 +51,20 @@ fn main() -> Result<()> {
                     &system_apps,
                     &mime,
                     json,
+                    &selector.unwrap_or(config.selector.clone()),
                     config.use_selector(enable_selector, disable_selector),
                 )?;
             }
             Cmd::Open {
                 paths,
+                selector,
                 enable_selector,
                 disable_selector,
             } => mime_apps.open_paths(
                 &config,
                 &system_apps,
                 &paths,
+                &selector.unwrap_or(config.selector.clone()),
                 config.use_selector(enable_selector, disable_selector),
             )?,
             Cmd::Mime { paths, json } => {


### PR DESCRIPTION
Adds `--selector`, `--enable-selector`, and `--disable-selector` flags to `handlr get`, `handlr open`, and `handlr launch`, the three subcommands that use the selector and updated manpages accordingly.

Closes #60