### PR TITLE
feat: add more flexible wildcards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "tabled",
  "thiserror",
  "url",
+ "wildmatch",
  "xdg",
  "xdg-mime",
 ]
@@ -1844,6 +1845,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3928939971918220fed093266b809d1ee4ec6c1a2d72692ff6876898f3b16c19"
 
 [[package]]
 name = "winapi"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ handlr set .png feh.desktop
 
 # Set wildcard handler for all text files
 handlr set 'text/*' nvim.desktop
+# Set wildcard handler for all OpenDocument formats
+# NOTE: startcenter.desktop is usually LibreOffice's main desktop entry
+handlr set 'application/vnd.oasis.opendocument.*' startcenter.desktop
 
 # Set default handler based on mime
 handlr set application/pdf evince.desktop

--- a/handlr-regex/Cargo.toml
+++ b/handlr-regex/Cargo.toml
@@ -31,6 +31,7 @@ freedesktop-desktop-entry = "0.6.1"
 derive_more = { version = "0.99.18", default-features = false, features = ["deref", "deref_mut"] }
 serde_ini = "0.2.0"
 serde_with = "3.8.3"
+wildmatch = "2.3.4"
 
 [[bin]]
 name = "handlr"

--- a/handlr-regex/src/config/main_config.rs
+++ b/handlr-regex/src/config/main_config.rs
@@ -45,17 +45,7 @@ impl Config {
             .get_handler_from_user(mime, selector, use_selector)
         {
             Err(e) if matches!(*e.kind, ErrorKind::Cancelled) => Err(e),
-            h => h
-                .or_else(|_| {
-                    let wildcard =
-                        Mime::from_str(&format!("{}/*", mime.type_()))?;
-                    self.mime_apps.get_handler_from_user(
-                        &wildcard,
-                        selector,
-                        use_selector,
-                    )
-                })
-                .or_else(|_| self.get_handler_from_added_associations(mime)),
+            h => h.or_else(|_| self.get_handler_from_added_associations(mime)),
         }
     }
 

--- a/handlr-regex/src/config/main_config.rs
+++ b/handlr-regex/src/config/main_config.rs
@@ -384,12 +384,47 @@ mod tests {
                 .to_string(),
             "mpv.desktop"
         );
-
         assert_eq!(
             config
                 .get_handler(&Mime::from_str("video/webm")?, "", false)?
                 .to_string(),
             "brave.desktop"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn complex_wildcard_mimes() -> Result<()> {
+        let mut config = Config::default();
+        config.mime_apps.add_handler(
+            &Mime::from_str("application/vnd.oasis.opendocument.*")?,
+            &DesktopHandler::assume_valid("startcenter.desktop".into()),
+        );
+        config.mime_apps.add_handler(
+            &Mime::from_str("application/vnd.openxmlformats-officedocument.*")?,
+            &DesktopHandler::assume_valid("startcenter.desktop".into()),
+        );
+
+        assert_eq!(
+            config
+                .get_handler(
+                    &Mime::from_str("application/vnd.oasis.opendocument.text")?,
+                    "",
+                    false
+                )?
+                .to_string(),
+            "startcenter.desktop"
+        );
+        assert_eq!(
+            config
+                .get_handler(
+                    &Mime::from_str("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")?,
+                    "",
+                    false
+                )?
+                .to_string(),
+            "startcenter.desktop"
         );
 
         Ok(())


### PR DESCRIPTION
Adds the ability to use wildcards for mimetypes other than having the entire subtype be wild.

For instance, now all of the OpenDocument formats can be matched with `application/vnd.oasis.opendocument.*` without also matching all of the other mimetypes under `application`.