### PR TITLE
fix: regressions related to editing mimeapps.list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,7 @@ dependencies = [
  "mime-db",
  "mutants",
  "once_cell",
+ "pretty_assertions",
  "regex",
  "serde",
  "serde_ini",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 goldie = "0.5.0"
+pretty_assertions = "1.4.0"
 
 [profile.release]
 opt-level = "z"

--- a/src/apps/system.rs
+++ b/src/apps/system.rs
@@ -5,10 +5,10 @@ use crate::{
 };
 use derive_more::Deref;
 use mime::Mime;
-use std::{collections::HashMap, convert::TryFrom, ffi::OsString, io::Write};
+use std::{collections::BTreeMap, convert::TryFrom, ffi::OsString, io::Write};
 
 #[derive(Debug, Default, Clone, Deref)]
-pub struct SystemApps(HashMap<Mime, DesktopList>);
+pub struct SystemApps(BTreeMap<Mime, DesktopList>);
 
 impl SystemApps {
     /// Get the list of handlers associated with a given mime
@@ -42,7 +42,7 @@ impl SystemApps {
     /// Create a new instance of `SystemApps`
     #[mutants::skip] // Cannot test directly, depends on system state
     pub fn populate() -> Result<Self> {
-        let mut map = HashMap::<Mime, DesktopList>::with_capacity(50);
+        let mut map = BTreeMap::<Mime, DesktopList>::new();
 
         Self::get_entries()?.for_each(|(_, entry)| {
             let (file_name, mimes) = (entry.file_name, entry.mime_type);
@@ -82,7 +82,7 @@ mod tests {
             .push_back(DesktopHandler::assume_valid("nvim.desktop".into()));
 
         let mime = Mime::from_str("text/plain")?;
-        let mut associations: HashMap<Mime, DesktopList> = HashMap::new();
+        let mut associations: BTreeMap<Mime, DesktopList> = BTreeMap::new();
 
         associations.insert(mime.clone(), expected_handlers.clone());
 

--- a/src/apps/user.rs
+++ b/src/apps/user.rs
@@ -283,9 +283,9 @@ fn select<O: Iterator<Item = String>>(
 
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
-
     use super::*;
+    use pretty_assertions::assert_eq;
+    use std::fs::File;
 
     fn test_add_handlers(mime_apps: &mut MimeApps) -> Result<()> {
         mime_apps.add_handler(
@@ -462,9 +462,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn mimeapps_no_added_round_trip() -> Result<()> {
-        let path = "./tests/mimeapps_no_added.list";
+    // Helper function to test serializing and deserializing mimeapps.list files
+    fn mimeapps_round_trip(path: &str) -> Result<()> {
         let file = File::open(path)?;
         let mime_apps = MimeApps::read_from(file)?;
 
@@ -481,20 +480,17 @@ mod tests {
     }
 
     #[test]
+    fn mimeapps_no_added_round_trip() -> Result<()> {
+        mimeapps_round_trip("./tests/mimeapps_no_added.list")
+    }
+
+    #[test]
     fn mimeapps_no_default_round_trip() -> Result<()> {
-        let path = "./tests/mimeapps_no_default.list";
-        let file = File::open(path)?;
-        let mime_apps = MimeApps::read_from(file)?;
+        mimeapps_round_trip("./tests/mimeapps_no_default.list")
+    }
 
-        let mut buffer = Vec::new();
-        mime_apps.save_to(&mut buffer)?;
-
-        assert_eq!(
-            String::from_utf8(buffer)?,
-            // Unfortunately, serde_ini outputs \r\n line endings
-            std::fs::read_to_string(path)?.replace('\n', "\r\n")
-        );
-
-        Ok(())
+    #[test]
+    fn mimeapps_sorted_round_trip() -> Result<()> {
+        mimeapps_round_trip("./tests/mimeapps_sorted.list")
     }
 }

--- a/src/apps/user.rs
+++ b/src/apps/user.rs
@@ -60,11 +60,15 @@ impl FromStr for DesktopList {
 /// Represents user-configured mimeapps.list file
 #[serde_as]
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+// IMPORTANT: This ensures missing fields are replaced by a default value rather than making deserialization fail entirely
+#[serde(default)]
 pub struct MimeApps {
     #[serde(rename = "Added Associations")]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde_as(as = "HashMap<DisplayFromStr, _>")]
     pub added_associations: HashMap<Mime, DesktopList>,
     #[serde(rename = "Default Applications")]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde_as(as = "HashMap<DisplayFromStr, _>")]
     pub default_apps: HashMap<Mime, DesktopList>,
 }

--- a/src/apps/user.rs
+++ b/src/apps/user.rs
@@ -12,6 +12,7 @@ use serde_with::{
 use std::{
     collections::{HashMap, VecDeque},
     fmt::Display,
+    io::Read,
     path::PathBuf,
     str::FromStr,
 };
@@ -184,7 +185,13 @@ impl MimeApps {
             .read(true)
             .open(Self::path()?)?;
 
-        let mut mimeapps: Self = serde_ini::de::from_read(file)?;
+        Self::read_from(file)
+    }
+
+    /// Create MimeApps from reader
+    /// Makes testing easier
+    fn read_from<R: Read>(reader: R) -> Result<Self> {
+        let mut mimeapps: Self = serde_ini::de::from_read(reader)?;
 
         // Remove empty default associations
         // Can happen if all handlers set are invalid (e.g. do not exist)

--- a/src/apps/user.rs
+++ b/src/apps/user.rs
@@ -12,7 +12,7 @@ use serde_with::{
 use std::{
     collections::{HashMap, VecDeque},
     fmt::Display,
-    io::Read,
+    io::{Read, Write},
     path::PathBuf,
     str::FromStr,
 };
@@ -35,13 +35,23 @@ pub struct DesktopList(VecDeque<DesktopHandler>);
 impl FromStr for DesktopList {
     type Err = Error;
 
-    #[mutants::skip] // Cannot test directly, depends on system state
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Kludge to help with testing this and things that rely on this
+        // Otherwise, this would depend on system state
+        fn filter(s: &str) -> Option<DesktopHandler> {
+            #[cfg(not(test))]
+            let result = DesktopHandler::from_str(s).ok();
+            #[cfg(test)]
+            let result = Some(DesktopHandler::assume_valid(s.into()));
+
+            result
+        }
+
         Ok(Self(
             s.split(';')
                 .filter(|s| !s.is_empty()) // Account for ending semicolon
                 .unique()
-                .filter_map(|s| DesktopHandler::from_str(s).ok())
+                .filter_map(filter)
                 .collect::<VecDeque<DesktopHandler>>(),
         ))
     }
@@ -188,7 +198,7 @@ impl MimeApps {
         Self::read_from(file)
     }
 
-    /// Create MimeApps from reader
+    /// Deserialize MimeApps from reader
     /// Makes testing easier
     fn read_from<R: Read>(reader: R) -> Result<Self> {
         let mut mimeapps: Self = serde_ini::de::from_read(reader)?;
@@ -203,15 +213,20 @@ impl MimeApps {
     /// Save associations to mimeapps.list
     #[mutants::skip] // Cannot test directly, alters system state
     pub fn save(&self) -> Result<()> {
-        let file = std::fs::OpenOptions::new()
+        let mut file = std::fs::OpenOptions::new()
             .read(true)
             .create(true)
             .write(true)
             .truncate(true)
             .open(Self::path()?)?;
 
-        serde_ini::ser::to_writer(file, self)?;
+        self.save_to(&mut file)
+    }
 
+    /// Serialize MimeApps and write to writer
+    /// Makes testing easier
+    fn save_to<W: Write>(&self, writer: &mut W) -> Result<()> {
+        serde_ini::ser::to_writer(writer, self)?;
         Ok(())
     }
 }
@@ -264,6 +279,8 @@ fn select<O: Iterator<Item = String>>(
 
 #[cfg(test)]
 mod tests {
+    use std::fs::File;
+
     use super::*;
 
     fn test_add_handlers(mime_apps: &mut MimeApps) -> Result<()> {
@@ -436,6 +453,42 @@ mod tests {
         assert_eq!(
             format!("{desktop_list}"),
             "helix.desktop;nvim.desktop;kakoune.desktop;"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn mimeapps_no_added_round_trip() -> Result<()> {
+        let path = "./tests/mimeapps_no_added.list";
+        let file = File::open(path)?;
+        let mime_apps = MimeApps::read_from(file)?;
+
+        let mut buffer = Vec::new();
+        mime_apps.save_to(&mut buffer)?;
+
+        assert_eq!(
+            String::from_utf8(buffer)?,
+            // Unfortunately, serde_ini outputs \r\n line endings
+            std::fs::read_to_string(path)?.replace('\n', "\r\n")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn mimeapps_no_default_round_trip() -> Result<()> {
+        let path = "./tests/mimeapps_no_default.list";
+        let file = File::open(path)?;
+        let mime_apps = MimeApps::read_from(file)?;
+
+        let mut buffer = Vec::new();
+        mime_apps.save_to(&mut buffer)?;
+
+        assert_eq!(
+            String::from_utf8(buffer)?,
+            // Unfortunately, serde_ini outputs \r\n line endings
+            std::fs::read_to_string(path)?.replace('\n', "\r\n")
         );
 
         Ok(())

--- a/src/apps/user.rs
+++ b/src/apps/user.rs
@@ -10,7 +10,7 @@ use serde_with::{
     serde_as, DeserializeFromStr, DisplayFromStr, SerializeDisplay,
 };
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, VecDeque},
     fmt::Display,
     io::{Read, Write},
     path::PathBuf,
@@ -64,13 +64,13 @@ impl FromStr for DesktopList {
 #[serde(default)]
 pub struct MimeApps {
     #[serde(rename = "Added Associations")]
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
-    pub added_associations: HashMap<Mime, DesktopList>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde_as(as = "BTreeMap<DisplayFromStr, _>")]
+    pub added_associations: BTreeMap<Mime, DesktopList>,
     #[serde(rename = "Default Applications")]
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
-    pub default_apps: HashMap<Mime, DesktopList>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde_as(as = "BTreeMap<DisplayFromStr, _>")]
+    pub default_apps: BTreeMap<Mime, DesktopList>,
 }
 
 impl Display for DesktopList {

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -30,13 +30,14 @@ pub struct Config {
 
 impl Config {
     /// Create a new instance of AppsConfig
-    pub fn new() -> Result<Self> {
-        Ok(Self {
-            mime_apps: MimeApps::read()?,
-            system_apps: SystemApps::populate()?,
-            config: ConfigFile::load()?,
+    pub fn new() -> Self {
+        Self {
+            // Ensure fields individually default rather than making the whole thing fail if one is missing
+            mime_apps: MimeApps::read().unwrap_or_default(),
+            system_apps: SystemApps::populate().unwrap_or_default(),
+            config: ConfigFile::load().unwrap_or_default(),
             terminal_output: std::io::stdout().is_terminal(),
-        })
+        }
     }
 
     /// Get the handler associated with a given mime

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -1,7 +1,7 @@
 use mime::Mime;
 use serde::Serialize;
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, VecDeque},
     io::{IsTerminal, Write},
     str::FromStr,
 };
@@ -405,7 +405,7 @@ impl MimeAppsTable {
         let separator = if terminal_output { ",\n" } else { ", " };
 
         let to_entries =
-            |map: &HashMap<Mime, DesktopList>| -> Vec<MimeAppsEntry> {
+            |map: &BTreeMap<Mime, DesktopList>| -> Vec<MimeAppsEntry> {
                 let mut rows = map
                     .iter()
                     .map(|(mime, handlers)| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::io::IsTerminal;
 
 #[mutants::skip] // Cannot test directly at the moment
 fn main() -> Result<()> {
-    let mut config = Config::new().unwrap_or_default();
+    let mut config = Config::new();
     let terminal_output = std::io::stdout().is_terminal();
     let mut stdout = std::io::stdout().lock();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,10 @@ use config::Config;
 use error::{ErrorKind, Result};
 
 use clap::Parser;
-use std::io::IsTerminal;
 
 #[mutants::skip] // Cannot test directly at the moment
 fn main() -> Result<()> {
     let mut config = Config::new();
-    let terminal_output = std::io::stdout().is_terminal();
     let mut stdout = std::io::stdout().lock();
 
     let res = || -> Result<()> {
@@ -71,7 +69,7 @@ fn main() -> Result<()> {
                 disable_selector,
             )?,
             Cmd::Mime { paths, json } => {
-                mime_table(&mut stdout, &paths, json, terminal_output)?;
+                mime_table(&mut stdout, &paths, json, config.terminal_output)?;
             }
             Cmd::List { all, json } => {
                 config.print(&mut stdout, all, json)?;
@@ -96,7 +94,7 @@ fn main() -> Result<()> {
         Ok(())
     }();
 
-    match (res, terminal_output) {
+    match (res, config.terminal_output) {
         (Err(e), _) if matches!(*e.kind, ErrorKind::Cancelled) => {
             std::process::exit(1);
         }

--- a/tests/mimeapps_no_added.list
+++ b/tests/mimeapps_no_added.list
@@ -1,0 +1,2 @@
+[Default Applications]
+text/*=nvim.desktop;

--- a/tests/mimeapps_no_default.list
+++ b/tests/mimeapps_no_default.list
@@ -1,0 +1,2 @@
+[Added Associations]
+x-scheme-handler/terminal=org.codeberg.dnkl.foot.desktop;

--- a/tests/mimeapps_sorted.list
+++ b/tests/mimeapps_sorted.list
@@ -1,0 +1,31 @@
+[Added Associations]
+video/vnd.youtube.yt=freetube.desktop;
+x-scheme-handler/terminal=org.wezfurlong.wezterm.desktop;org.codeberg.dnkl.foot.desktop;
+[Default Applications]
+application/msword=writer.desktop;
+application/pdf=org.pwmt.zathura-pdf-mupdf.desktop;
+application/vnd.ms-excel=calc.desktop;
+application/vnd.ms-powerpoint=impress.desktop;
+application/vnd.oasis.opendocument.database=base.desktop;
+application/vnd.oasis.opendocument.formula=math.desktop;
+application/vnd.oasis.opendocument.graphics=draw.desktop;
+application/vnd.oasis.opendocument.presentation=impress.desktop;
+application/vnd.oasis.opendocument.presentation-template=impress.desktop;
+application/vnd.oasis.opendocument.spreadsheet=calc.desktop;
+application/vnd.oasis.opendocument.spreadsheet-flat-xml=calc.desktop;
+application/vnd.oasis.opendocument.text=writer.desktop;
+application/vnd.oasis.opendocument.text-template=writer.desktop;
+application/vnd.openxmlformats-officedocument.presentationml.presentation=impress.desktop;
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet=calc.desktop;
+application/vnd.openxmlformats-officedocument.wordprocessingml.document=writer.desktop;
+application/vnd.openxmlformats-officedocument.wordprocessingml.template=writer.desktop;
+application/x-yaml=Helix.desktop;
+audio/*=org.strawberrymusicplayer.strawberry.desktop;
+image/*=imv.desktop;
+inode/directory=yazi.desktop;
+text/*=Helix.desktop;nvim.desktop;
+text/html=firefox.desktop;Helix.desktop;nvim.desktop;
+video/*=mpv.desktop;
+x-scheme-handler/http=firefox.desktop;
+x-scheme-handler/https=firefox.desktop;
+x-scheme-handler/terminal=org.wezfurlong.wezterm.desktop;


### PR DESCRIPTION
Fixes a regression discussed in #68: If there is no `[Added Associations]` or `[Default Applications]` section in `mimeapps.list`, `handlr` will wipe `mimeapps.list` if one runs a subcommand that edits it (e.g. `handlr set`). Also fortunately closes #69.

Also fixes other regressions I noticed while fixing the above:
- The `mimeapps.list` and `handlr.toml` files both get ignored in favor of default values if either are missing.
- The associations in `mimeapps.list` get saved in a random order after editing it with `handlr`.

In addition, adds regression tests for the above problems where applicable and has some minor refactoring.