### PR TITLE
fix: bugs mentioned in discussions #68 and #47

### DIFF
--- a/src/common/desktop_entry.rs
+++ b/src/common/desktop_entry.rs
@@ -143,7 +143,8 @@ impl DesktopEntry {
 
         // If the entry expects a terminal (emulator), but this process is not running in one, we
         // launch a new one.
-        if self.terminal && config.terminal_output {
+        // TODO: make regression test (currently infeasible with terminal method's reliance on system state)
+        if self.terminal && !config.terminal_output {
             let term_cmd = config.terminal(selector, use_selector)?;
             exec = shlex::split(&term_cmd)
                 .ok_or_else(|| Error::from(ErrorKind::BadCmd(term_cmd)))?

--- a/src/common/mime_types.rs
+++ b/src/common/mime_types.rs
@@ -147,6 +147,10 @@ mod tests {
             MimeType::try_from(Path::new("./tests/no_html_tags.html"))?.0,
             "text/html"
         );
+        assert_eq!(
+            MimeType::try_from(Path::new("./tests/empty"))?.0,
+            "application/x-zerosize"
+        );
 
         Ok(())
     }

--- a/src/common/mime_types.rs
+++ b/src/common/mime_types.rs
@@ -40,12 +40,16 @@ impl TryFrom<&Path> for MimeType {
         guess.file_name(&path.to_string_lossy());
 
         let mime = if let Some(mime) =
-            mime_to_option(&db, guess.guess().mime_type().clone())
+            mime_to_option(&db, guess.guess().mime_type().clone(), true)
         {
             mime
         } else {
-            mime_to_option(&db, guess.path(path).guess().mime_type().clone())
-                .ok_or_else(|| ErrorKind::Ambiguous(path.to_owned()))?
+            mime_to_option(
+                &db,
+                guess.path(path).guess().mime_type().clone(),
+                false,
+            )
+            .ok_or_else(|| ErrorKind::Ambiguous(path.to_owned()))?
         };
 
         Ok(Self(mime))
@@ -53,11 +57,16 @@ impl TryFrom<&Path> for MimeType {
 }
 
 /// Tests if a given mime is "acceptable" and returns None otherwise
-fn mime_to_option(db: &xdg_mime::SharedMimeInfo, mime: Mime) -> Option<Mime> {
+fn mime_to_option(
+    db: &xdg_mime::SharedMimeInfo,
+    mime: Mime,
+    discard_zerosize: bool,
+) -> Option<Mime> {
     let application_zerosize: Mime = "application/x-zerosize".parse().ok()?;
 
     if mime == mime::APPLICATION_OCTET_STREAM
-        || db.mime_type_equal(&mime, &application_zerosize)
+        || (db.mime_type_equal(&mime, &application_zerosize)
+            && discard_zerosize)
     {
         None
     } else {


### PR DESCRIPTION
Fixes an issue with opening terminal applications discussed in #68 and discarding `application/x-zerosize` mimetypes in #47.

I could not add a reliable regression test for the issue regarding opening terminal applications, because of issues with how fetching the command from the `x-scheme-handler/terminal` handler currently. Namely, issues with how it sets a handler if there is none. I intend to rework this behavior later.