### PR TITLE
refactor: clean up selector options implementation

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
-use crate::common::{DesktopHandler, MimeOrExtension, UserPath};
-use clap::Parser;
+pub use crate::common::{DesktopHandler, MimeOrExtension, UserPath};
+use clap::{Args, Parser};
 
 /// A better xdg-utils
 ///
@@ -69,16 +69,8 @@ pub enum Cmd {
         #[clap(required = true)]
         /// Paths/URLs to open
         paths: Vec<UserPath>,
-        #[clap(long, short)]
-        /// Override the configured selector command
-        selector: Option<String>,
-        #[clap(long, short)]
-        /// Enable selector, overrides `enable_selector`
-        enable_selector: bool,
-        #[clap(long, short)]
-        #[clap(overrides_with = "enable_selector")]
-        /// Disable selector, overrides `enable_selector`
-        disable_selector: bool,
+        #[command(flatten)]
+        selector_args: SelectorArgs,
     },
 
     /// Set the default handler for mime/extension
@@ -121,16 +113,8 @@ pub enum Cmd {
         mime: MimeOrExtension,
         /// Arguments to pass to handler program
         args: Vec<UserPath>,
-        #[clap(long, short)]
-        /// Override the configured selector command
-        selector: Option<String>,
-        #[clap(long, short)]
-        /// Enable selector, overrides `enable_selector`
-        enable_selector: bool,
-        #[clap(long, short)]
-        #[clap(overrides_with = "enable_selector")]
-        /// Disable selector, overrides `enable_selector`
-        disable_selector: bool,
+        #[command(flatten)]
+        selector_args: SelectorArgs,
     },
 
     #[clap(verbatim_doc_comment)]
@@ -158,16 +142,8 @@ pub enum Cmd {
         json: bool,
         /// Mimetype to get the handler of
         mime: MimeOrExtension,
-        #[clap(long, short)]
-        /// Override the configured selector command
-        selector: Option<String>,
-        #[clap(long, short)]
-        /// Enable selector, overrides `enable_selector`
-        enable_selector: bool,
-        #[clap(long, short)]
-        #[clap(overrides_with = "enable_selector")]
-        /// Disable selector, overrides `enable_selector`
-        disable_selector: bool,
+        #[command(flatten)]
+        selector_args: SelectorArgs,
     },
 
     /// Add a handler for given mime/extension
@@ -238,4 +214,18 @@ pub enum Cmd {
         /// Autocomplete for mimetypes/file extensions
         mimes: bool,
     },
+}
+
+#[derive(Clone, Args)]
+pub struct SelectorArgs {
+    #[clap(long, short)]
+    /// Override the configured selector command
+    pub selector: Option<String>,
+    #[clap(long, short)]
+    /// Enable selector, overrides `enable_selector`
+    pub enable_selector: bool,
+    #[clap(long, short)]
+    #[clap(overrides_with = "enable_selector")]
+    /// Disable selector, overrides `enable_selector`
+    pub disable_selector: bool,
 }

--- a/src/common/handler.rs
+++ b/src/common/handler.rs
@@ -25,20 +25,8 @@ pub trait Handleable {
     fn get_entry(&self) -> Result<DesktopEntry>;
     /// Open the given paths with the handler
     #[mutants::skip] // Cannot test directly, runs commands
-    fn open(
-        &self,
-        config: &Config,
-        args: Vec<String>,
-        selector: &str,
-        enable_selector: bool,
-    ) -> Result<()> {
-        self.get_entry()?.exec(
-            config,
-            ExecMode::Open,
-            args,
-            selector,
-            enable_selector,
-        )
+    fn open(&self, config: &Config, args: Vec<String>) -> Result<()> {
+        self.get_entry()?.exec(config, ExecMode::Open, args)
     }
 }
 
@@ -90,20 +78,8 @@ impl DesktopHandler {
 
     /// Launch a DesktopHandler's desktop entry
     #[mutants::skip] // Cannot test directly, runs command
-    pub fn launch(
-        &self,
-        config: &Config,
-        args: Vec<String>,
-        selector: &str,
-        enable_selector: bool,
-    ) -> Result<()> {
-        self.get_entry()?.exec(
-            config,
-            ExecMode::Launch,
-            args,
-            selector,
-            enable_selector,
-        )
+    pub fn launch(&self, config: &Config, args: Vec<String>) -> Result<()> {
+        self.get_entry()?.exec(config, ExecMode::Launch, args)
     }
 }
 

--- a/src/config/config_file.rs
+++ b/src/config/config_file.rs
@@ -1,4 +1,5 @@
 use crate::{
+    cli::SelectorArgs,
     common::{RegexApps, RegexHandler, UserPath},
     error::Result,
 };
@@ -46,12 +47,25 @@ impl ConfigFile {
     }
 
     /// Determine whether or not the selector should be enabled
-    pub fn use_selector(
+    fn use_selector(
         &self,
         enable_selector: bool,
         disable_selector: bool,
     ) -> bool {
         (self.enable_selector || enable_selector) && !disable_selector
+    }
+
+    /// Override the set selector
+    /// Currently assumes the config file will never be saved to
+    pub fn override_selector(&mut self, selector_args: SelectorArgs) {
+        if let Some(selector) = selector_args.selector {
+            self.selector = selector;
+        }
+
+        self.enable_selector = self.use_selector(
+            selector_args.enable_selector,
+            selector_args.disable_selector,
+        )
     }
 }
 

--- a/src/config/config_file.rs
+++ b/src/config/config_file.rs
@@ -46,15 +46,6 @@ impl ConfigFile {
         Ok(confy::load("handlr")?)
     }
 
-    /// Determine whether or not the selector should be enabled
-    fn use_selector(
-        &self,
-        enable_selector: bool,
-        disable_selector: bool,
-    ) -> bool {
-        (self.enable_selector || enable_selector) && !disable_selector
-    }
-
     /// Override the set selector
     /// Currently assumes the config file will never be saved to
     pub fn override_selector(&mut self, selector_args: SelectorArgs) {
@@ -62,36 +53,8 @@ impl ConfigFile {
             self.selector = selector;
         }
 
-        self.enable_selector = self.use_selector(
-            selector_args.enable_selector,
-            selector_args.disable_selector,
-        )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_use_selector() -> Result<()> {
-        let mut config_file = ConfigFile {
-            enable_selector: true,
-            ..Default::default()
-        };
-
-        assert!(config_file.use_selector(true, false));
-        assert!(config_file.use_selector(false, false));
-        assert!(!config_file.use_selector(false, true));
-        assert!(!config_file.use_selector(true, true));
-
-        config_file.enable_selector = false;
-
-        assert!(config_file.use_selector(true, false));
-        assert!(!config_file.use_selector(false, false));
-        assert!(!config_file.use_selector(false, true));
-        assert!(!config_file.use_selector(true, true));
-
-        Ok(())
+        self.enable_selector = (self.enable_selector
+            || selector_args.enable_selector)
+            && !selector_args.disable_selector;
     }
 }

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -762,4 +762,88 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn override_selector() -> Result<()> {
+        let mut config = Config::default();
+
+        // Ensure defaults are as expected just in case
+        assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");
+        assert_eq!(config.config.enable_selector, false);
+
+        config.override_selector(SelectorArgs {
+            selector: Some("fzf".to_string()),
+            enable_selector: true,
+            disable_selector: false,
+        });
+
+        assert_eq!(config.config.selector, "fzf");
+        assert_eq!(config.config.enable_selector, true);
+
+        config.override_selector(SelectorArgs {
+            selector: Some("fuzzel --dmenu --prompt='Open With: '".to_string()),
+            enable_selector: false,
+            disable_selector: true,
+        });
+
+        assert_eq!(
+            config.config.selector,
+            "fuzzel --dmenu --prompt='Open With: '"
+        );
+        assert_eq!(config.config.enable_selector, false);
+
+        Ok(())
+    }
+
+    #[test]
+    fn dont_override_selector() -> Result<()> {
+        // NOTE: `enable_selector` and `disable_selector` should not both be true in practice anyways
+
+        let mut config = Config::default();
+
+        // Ensure defaults are as expected just in case
+        assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");
+        assert_eq!(config.config.enable_selector, false);
+
+        config.override_selector(SelectorArgs {
+            selector: None,
+            enable_selector: false,
+            disable_selector: false,
+        });
+
+        assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");
+        assert_eq!(config.config.enable_selector, false);
+
+        config.override_selector(SelectorArgs {
+            selector: None,
+            enable_selector: false,
+            disable_selector: true,
+        });
+
+        assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");
+        assert_eq!(config.config.enable_selector, false);
+
+        // Now repeat with `enable_selector` set to true
+        config.config.enable_selector = true;
+
+        config.override_selector(SelectorArgs {
+            selector: None,
+            enable_selector: true,
+            disable_selector: false,
+        });
+
+        assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");
+        assert_eq!(config.config.enable_selector, true);
+
+        config.override_selector(SelectorArgs {
+            selector: None,
+            enable_selector: false,
+            disable_selector: false,
+        });
+
+        assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");
+        assert_eq!(config.config.enable_selector, true);
+
+        Ok(())
+    }
 }

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -43,11 +43,7 @@ impl Config {
 
     /// Get the handler associated with a given mime
     pub fn get_handler(&self, mime: &Mime) -> Result<DesktopHandler> {
-        match self.mime_apps.get_handler_from_user(
-            mime,
-            &self.config.selector,
-            self.config.enable_selector,
-        ) {
+        match self.mime_apps.get_handler_from_user(mime, &self.config) {
             Err(e) if matches!(*e.kind, ErrorKind::Cancelled) => Err(e),
             h => h.or_else(|_| self.get_handler_from_added_associations(mime)),
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod config_file;
 mod main_config;
 
+pub use config_file::ConfigFile;
 pub use main_config::Config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,37 +31,24 @@ fn main() -> Result<()> {
                 args,
                 selector_args,
             } => {
-                config.launch_handler(
-                    &mime,
-                    args,
-                    selector_args.selector,
-                    selector_args.enable_selector,
-                    selector_args.disable_selector,
-                )?;
+                config.override_selector(selector_args);
+                config.launch_handler(&mime, args)?;
             }
             Cmd::Get {
                 mime,
                 json,
                 selector_args,
             } => {
-                config.show_handler(
-                    &mut stdout,
-                    &mime,
-                    json,
-                    selector_args.selector,
-                    selector_args.enable_selector,
-                    selector_args.disable_selector,
-                )?;
+                config.override_selector(selector_args);
+                config.show_handler(&mut stdout, &mime, json)?;
             }
             Cmd::Open {
                 paths,
                 selector_args,
-            } => config.open_paths(
-                &paths,
-                selector_args.selector,
-                selector_args.enable_selector,
-                selector_args.disable_selector,
-            )?,
+            } => {
+                config.override_selector(selector_args);
+                config.open_paths(&paths)?;
+            }
             Cmd::Mime { paths, json } => {
                 mime_table(&mut stdout, &paths, json, config.terminal_output)?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,44 +29,38 @@ fn main() -> Result<()> {
             Cmd::Launch {
                 mime,
                 args,
-                selector,
-                enable_selector,
-                disable_selector,
+                selector_args,
             } => {
                 config.launch_handler(
                     &mime,
                     args,
-                    selector,
-                    enable_selector,
-                    disable_selector,
+                    selector_args.selector,
+                    selector_args.enable_selector,
+                    selector_args.disable_selector,
                 )?;
             }
             Cmd::Get {
                 mime,
                 json,
-                selector,
-                enable_selector,
-                disable_selector,
+                selector_args,
             } => {
                 config.show_handler(
                     &mut stdout,
                     &mime,
                     json,
-                    selector,
-                    enable_selector,
-                    disable_selector,
+                    selector_args.selector,
+                    selector_args.enable_selector,
+                    selector_args.disable_selector,
                 )?;
             }
             Cmd::Open {
                 paths,
-                selector,
-                enable_selector,
-                disable_selector,
+                selector_args,
             } => config.open_paths(
                 &paths,
-                selector,
-                enable_selector,
-                disable_selector,
+                selector_args.selector,
+                selector_args.enable_selector,
+                selector_args.disable_selector,
             )?,
             Cmd::Mime { paths, json } => {
                 mime_table(&mut stdout, &paths, json, config.terminal_output)?;


### PR DESCRIPTION
Mainly makes the logic for the selector-related flags reusable and DRY and avoids passing down selector options rather than passing state using a struct.