### PR TITLE
Fix issue with opening multiple files of different types

### DIFF
--- a/src/common/handler.rs
+++ b/src/common/handler.rs
@@ -135,6 +135,7 @@ impl RegexSet {
 }
 
 impl PartialEq for RegexSet {
+    #[mutants::skip] // Trivial
     fn eq(&self, other: &Self) -> bool {
         self.patterns() == other.patterns()
     }
@@ -143,6 +144,7 @@ impl PartialEq for RegexSet {
 impl Eq for RegexSet {}
 
 impl Hash for RegexSet {
+    #[mutants::skip] // Trivial
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.patterns().hash(state);
     }

--- a/src/common/handler.rs
+++ b/src/common/handler.rs
@@ -23,6 +23,14 @@ pub enum Handler {
     RegexHandler,
 }
 
+#[cfg(test)]
+impl Handler {
+    /// Helper function for testing
+    pub fn new(name: &str) -> Self {
+        Handler::DesktopHandler(DesktopHandler::assume_valid(name.into()))
+    }
+}
+
 /// Trait providing common functionality for handlers
 #[enum_dispatch]
 pub trait Handleable {

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -127,6 +127,20 @@ impl Config {
     /// Open the given paths with their respective handlers
     #[mutants::skip] // Cannot test directly, runs external commands
     pub fn open_paths(&self, paths: &[UserPath]) -> Result<()> {
+        for (handler, paths) in
+            self.assign_files_to_handlers(paths)?.into_iter()
+        {
+            handler.open(self, paths)?;
+        }
+
+        Ok(())
+    }
+
+    /// Helper function to assign files to their respective handlers
+    fn assign_files_to_handlers(
+        &self,
+        paths: &[UserPath],
+    ) -> Result<HashMap<Handler, Vec<String>>> {
         let mut handlers: HashMap<Handler, Vec<String>> = HashMap::new();
 
         for path in paths.iter() {
@@ -136,11 +150,7 @@ impl Config {
                 .push(path.to_string())
         }
 
-        for (handler, paths) in handlers.into_iter() {
-            handler.open(self, paths)?;
-        }
-
-        Ok(())
+        Ok(handlers)
     }
 
     /// Get the handler associated with a given path

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -856,4 +856,67 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn properly_assign_files_to_handlers() -> Result<()> {
+        let mut config = Config::default();
+        config.add_handler(
+            &Mime::from_str("image/png")?,
+            &DesktopHandler::assume_valid("swayimg.desktop".into()),
+        )?;
+        config.add_handler(
+            &Mime::from_str("application/pdf")?,
+            &DesktopHandler::assume_valid("mupdf.desktop".into()),
+        )?;
+
+        let mut expected_handlers = HashMap::new();
+        expected_handlers
+            .insert(Handler::new("swayimg.desktop"), vec!["a.png".to_owned()]);
+        expected_handlers
+            .insert(Handler::new("mupdf.desktop"), vec!["a.pdf".to_owned()]);
+
+        assert_eq!(
+            config.assign_files_to_handlers(&[
+                UserPath::from_str("a.png")?,
+                UserPath::from_str("a.pdf")?
+            ])?,
+            expected_handlers
+        );
+
+        assert_eq!(
+            config.assign_files_to_handlers(&[
+                UserPath::from_str("a.pdf")?,
+                UserPath::from_str("a.png")?
+            ])?,
+            expected_handlers
+        );
+
+        let mut expected_handlers = HashMap::new();
+        expected_handlers.insert(
+            Handler::new("swayimg.desktop"),
+            vec!["a.png".to_owned(), "b.png".to_owned()],
+        );
+        expected_handlers
+            .insert(Handler::new("mupdf.desktop"), vec!["a.pdf".to_owned()]);
+
+        assert_eq!(
+            config.assign_files_to_handlers(&[
+                UserPath::from_str("a.png")?,
+                UserPath::from_str("b.png")?,
+                UserPath::from_str("a.pdf")?
+            ])?,
+            expected_handlers
+        );
+
+        assert_eq!(
+            config.assign_files_to_handlers(&[
+                UserPath::from_str("a.pdf")?,
+                UserPath::from_str("a.png")?,
+                UserPath::from_str("b.png")?
+            ])?,
+            expected_handlers
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixes #76.

Apparently, the handlers were getting hashed based on what kind of handler they were (i.e. `DesktopHandler` vs. `RegexHandler`), so when using a HashMap to assign files to their respective handlers, they ended up all getting sorted to the same handler and causing issues.