### PR TITLE
fix: use a line feed, not a carriage return at the end of the file

### DIFF
--- a/src/apps/user.rs
+++ b/src/apps/user.rs
@@ -311,7 +311,15 @@ impl MimeApps {
     fn save_to<W: Write>(&mut self, writer: &mut W) -> Result<()> {
         // Remove empty entries
         self.default_apps.retain(|_, handlers| !handlers.is_empty());
-        serde_ini::ser::to_writer(writer, self)?;
+
+        // Use Linefeed instead of default carriage return
+        let w = serde_ini::write::Writer::new(
+            writer,
+            serde_ini::write::LineEnding::Linefeed,
+        );
+        let mut ser = serde_ini::ser::Serializer::new(w);
+        self.serialize(&mut ser)?;
+
         Ok(())
     }
 }

--- a/src/apps/user.rs
+++ b/src/apps/user.rs
@@ -392,8 +392,7 @@ mod tests {
 
         assert_eq!(
             String::from_utf8(buffer)?,
-            // Unfortunately, serde_ini outputs \r\n line endings
-            std::fs::read_to_string(expected_path)?.replace('\n', "\r\n")
+            std::fs::read_to_string(expected_path)?
         );
 
         Ok(())


### PR DESCRIPTION
Fixes #78