### PR TITLE
fix: do not ignore config errors

### DIFF
--- a/src/common/desktop_entry.rs
+++ b/src/common/desktop_entry.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::Config,
-    error::{Error, ErrorKind, Result},
+    error::{Error, Result},
 };
 use aho_corasick::AhoCorasick;
 use freedesktop_desktop_entry::{
@@ -96,10 +96,10 @@ impl DesktopEntry {
             AhoCorasick::new_auto_configured(&["%f", "%F", "%u", "%U"]);
 
         let mut exec = shlex::split(&self.exec).ok_or_else(|| {
-            Error::from(ErrorKind::BadExec(
+            Error::BadExec(
                 self.exec.clone(),
                 self.file_name.to_string_lossy().to_string(),
-            ))
+            )
         })?;
 
         // The desktop entry doesn't contain arguments - we make best effort and append them at
@@ -134,7 +134,7 @@ impl DesktopEntry {
         if self.terminal && !config.terminal_output {
             let term_cmd = config.terminal()?;
             exec = shlex::split(&term_cmd)
-                .ok_or_else(|| Error::from(ErrorKind::BadCmd(term_cmd)))?
+                .ok_or_else(|| Error::BadCmd(term_cmd))?
                 .into_iter()
                 .chain(exec)
                 .collect();
@@ -196,7 +196,7 @@ impl DesktopEntry {
 impl TryFrom<PathBuf> for DesktopEntry {
     type Error = Error;
     fn try_from(path: PathBuf) -> Result<Self> {
-        Self::parse_file(&path).ok_or(Error::from(ErrorKind::BadEntry(path)))
+        Self::parse_file(&path).ok_or(Error::BadEntry(path))
     }
 }
 

--- a/src/common/handler.rs
+++ b/src/common/handler.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{DesktopEntry, ExecMode, UserPath},
     config::Config,
-    error::{Error, ErrorKind, Result},
+    error::{Error, Result},
 };
 use derive_more::Deref;
 use enum_dispatch::enum_dispatch;
@@ -84,7 +84,7 @@ impl DesktopHandler {
             Ok(xdg::BaseDirectories::new()?
                 .find_data_file(path)
                 .ok_or_else(|| {
-                    ErrorKind::NotFound(name.to_string_lossy().into())
+                    Error::NotFound(name.to_string_lossy().into())
                 })?)
         }
     }
@@ -161,7 +161,7 @@ impl RegexApps {
             .0
             .iter()
             .find(|app| app.is_match(&path.to_string()))
-            .ok_or_else(|| ErrorKind::NotFound(path.to_string()))?
+            .ok_or_else(|| Error::NotFound(path.to_string()))?
             .clone())
     }
 }

--- a/src/common/path.rs
+++ b/src/common/path.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::{render_table, MimeType},
-    error::{Error, ErrorKind, Result},
+    error::{Error, Result},
 };
 use mime::Mime;
 use serde::Serialize;
@@ -35,9 +35,9 @@ impl FromStr for UserPath {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let normalized = match url::Url::parse(s) {
             Ok(url) if url.scheme() == "file" => {
-                let path = url.to_file_path().map_err(|_| {
-                    Error::from(ErrorKind::BadPath(url.path().to_owned()))
-                })?;
+                let path = url
+                    .to_file_path()
+                    .map_err(|_| Error::BadPath(url.path().to_owned()))?;
 
                 Self::File(path)
             }

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -31,14 +31,14 @@ pub struct Config {
 
 impl Config {
     /// Create a new instance of AppsConfig
-    pub fn new() -> Self {
-        Self {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
             // Ensure fields individually default rather than making the whole thing fail if one is missing
-            mime_apps: MimeApps::read().unwrap_or_default(),
-            system_apps: SystemApps::populate().unwrap_or_default(),
-            config: ConfigFile::load().unwrap_or_default(),
+            mime_apps: MimeApps::read()?,
+            system_apps: SystemApps::populate()?,
+            config: ConfigFile::load()?,
             terminal_output: std::io::stdout().is_terminal(),
-        }
+        })
     }
 
     /// Get the handler associated with a given mime

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -13,6 +13,7 @@ use crate::{
     common::{render_table, DesktopHandler, Handleable, Handler, UserPath},
     config::config_file::ConfigFile,
     error::{Error, Result},
+    utils,
 };
 
 /// A single struct that holds all apps and config.
@@ -32,12 +33,23 @@ pub struct Config {
 impl Config {
     /// Create a new instance of AppsConfig
     pub fn new() -> Result<Self> {
+        let config = ConfigFile::load();
+        let terminal_output = std::io::stdout().is_terminal();
+
+        // Issue a notification if handlr is not being run in a terminal
+        // Config's errors are not able to be handled by `main`'s similar error handling
+        if let Err(ref e) = config {
+            if !terminal_output {
+                utils::notify("handlr error", &e.to_string())?
+            }
+        }
+
         Ok(Self {
             // Ensure fields individually default rather than making the whole thing fail if one is missing
             mime_apps: MimeApps::read()?,
             system_apps: SystemApps::populate()?,
-            config: ConfigFile::load()?,
-            terminal_output: std::io::stdout().is_terminal(),
+            config: config?,
+            terminal_output,
         })
     }
 

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -12,7 +12,7 @@ use crate::{
     cli::SelectorArgs,
     common::{render_table, DesktopHandler, Handleable, Handler, UserPath},
     config::config_file::ConfigFile,
-    error::{Error, ErrorKind, Result},
+    error::{Error, Result},
 };
 
 /// A single struct that holds all apps and config.
@@ -44,7 +44,7 @@ impl Config {
     /// Get the handler associated with a given mime
     pub fn get_handler(&self, mime: &Mime) -> Result<DesktopHandler> {
         match self.mime_apps.get_handler_from_user(mime, &self.config) {
-            Err(e) if matches!(*e.kind, ErrorKind::Cancelled) => Err(e),
+            Err(e) if matches!(e, Error::Cancelled) => Err(e),
             h => h.or_else(|_| self.get_handler_from_added_associations(mime)),
         }
     }
@@ -62,7 +62,7 @@ impl Config {
                 || self.system_apps.get_handler(mime),
                 |h| h.front().cloned(),
             )
-            .ok_or_else(|| Error::from(ErrorKind::NotFound(mime.to_string())))
+            .ok_or_else(|| Error::NotFound(mime.to_string()))
     }
 
     /// Given a mime and arguments, launch the associated handler with the arguments
@@ -190,7 +190,7 @@ impl Config {
 
                 exec
             })
-            .ok_or_else(|| Error::from(ErrorKind::NoTerminal))
+            .ok_or_else(|| Error::NoTerminal)
     }
 
     /// Print the set associations and system-level associations in a table

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,24 +1,6 @@
 /// Custom error type
 #[derive(Debug, thiserror::Error)]
-#[error(transparent)]
-pub struct Error {
-    pub kind: Box<ErrorKind>,
-}
-
-impl<E> From<E> for Error
-where
-    ErrorKind: From<E>,
-{
-    fn from(err: E) -> Self {
-        Error {
-            kind: Box::new(ErrorKind::from(err)),
-        }
-    }
-}
-
-/// Custom error messages
-#[derive(Debug, thiserror::Error)]
-pub enum ErrorKind {
+pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error(transparent)]
@@ -60,7 +42,7 @@ pub enum ErrorKind {
     BadUrl(#[from] url::ParseError),
     #[cfg(test)]
     #[error(transparent)]
-    FromUtf8Error(#[from] std::string::FromUtf8Error),
+    FromUtf8(#[from] std::string::FromUtf8Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use apps::SystemApps;
 use cli::Cmd;
 use common::mime_table;
 use config::Config;
-use error::{Error, Result};
+use error::Result;
 
 use clap::Parser;
 
@@ -18,75 +18,57 @@ fn main() -> Result<()> {
     let mut config = Config::new()?;
     let mut stdout = std::io::stdout().lock();
 
-    let res = || -> Result<()> {
-        match Cmd::parse() {
-            Cmd::Set { mime, handler } => {
-                config.set_handler(&mime, &handler)?
-            }
-            Cmd::Add { mime, handler } => {
-                config.add_handler(&mime, &handler)?
-            }
-            Cmd::Launch {
-                mime,
-                args,
-                selector_args,
-            } => {
-                config.override_selector(selector_args);
-                config.launch_handler(&mime, args)?;
-            }
-            Cmd::Get {
-                mime,
-                json,
-                selector_args,
-            } => {
-                config.override_selector(selector_args);
-                config.show_handler(&mut stdout, &mime, json)?;
-            }
-            Cmd::Open {
-                paths,
-                selector_args,
-            } => {
-                config.override_selector(selector_args);
-                config.open_paths(&paths)?;
-            }
-            Cmd::Mime { paths, json } => {
-                mime_table(&mut stdout, &paths, json, config.terminal_output)?;
-            }
-            Cmd::List { all, json } => {
-                config.print(&mut stdout, all, json)?;
-            }
-            Cmd::Unset { mime } => {
-                config.unset_handler(&mime)?;
-            }
-            Cmd::Remove { mime, handler } => {
-                config.remove_handler(&mime, &handler)?;
-            }
-            Cmd::Autocomplete {
-                desktop_files,
-                mimes,
-            } => {
-                if desktop_files {
-                    SystemApps::list_handlers(&mut stdout)?;
-                } else if mimes {
-                    common::db_autocomplete(&mut stdout)?;
-                }
-            }
+    let res = match Cmd::parse() {
+        Cmd::Set { mime, handler } => config.set_handler(&mime, &handler),
+        Cmd::Add { mime, handler } => config.add_handler(&mime, &handler),
+        Cmd::Launch {
+            mime,
+            args,
+            selector_args,
+        } => {
+            config.override_selector(selector_args);
+            config.launch_handler(&mime, args)
         }
-        Ok(())
-    }();
+        Cmd::Get {
+            mime,
+            json,
+            selector_args,
+        } => {
+            config.override_selector(selector_args);
+            config.show_handler(&mut stdout, &mime, json)
+        }
+        Cmd::Open {
+            paths,
+            selector_args,
+        } => {
+            config.override_selector(selector_args);
+            config.open_paths(&paths)
+        }
+        Cmd::Mime { paths, json } => {
+            mime_table(&mut stdout, &paths, json, config.terminal_output)
+        }
+        Cmd::List { all, json } => config.print(&mut stdout, all, json),
+        Cmd::Unset { mime } => config.unset_handler(&mime),
+        Cmd::Remove { mime, handler } => config.remove_handler(&mime, &handler),
+        Cmd::Autocomplete {
+            desktop_files,
+            mimes,
+        } => {
+            if desktop_files {
+                SystemApps::list_handlers(&mut stdout)?;
+            } else if mimes {
+                common::db_autocomplete(&mut stdout)?;
+            }
+            Ok(())
+        }
+    };
 
-    match (res, config.terminal_output) {
-        (Err(Error::Cancelled), _) => {
-            std::process::exit(1);
+    // Issue a notification if handlr is not being run in a terminal
+    if let Err(ref e) = res {
+        if !config.terminal_output {
+            utils::notify("handlr error", &e.to_string())?
         }
-        (Err(e), true) => {
-            eprintln!("{}", e);
-            std::process::exit(1);
-        }
-        (Err(e), false) => {
-            utils::notify("handlr error", &e.to_string())?;
-            std::process::exit(1);
-        }
-        _ => Ok(()),
     }
+
+    res
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use clap::Parser;
 
 #[mutants::skip] // Cannot test directly at the moment
 fn main() -> Result<()> {
-    let mut config = Config::new();
+    let mut config = Config::new()?;
     let mut stdout = std::io::stdout().lock();
 
     let res = || -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use apps::SystemApps;
 use cli::Cmd;
 use common::mime_table;
 use config::Config;
-use error::{ErrorKind, Result};
+use error::{Error, Result};
 
 use clap::Parser;
 
@@ -76,7 +76,7 @@ fn main() -> Result<()> {
     }();
 
     match (res, config.terminal_output) {
-        (Err(e), _) if matches!(*e.kind, ErrorKind::Cancelled) => {
+        (Err(Error::Cancelled), _) => {
             std::process::exit(1);
         }
         (Err(e), true) => {


### PR DESCRIPTION
Stop ignoring config errors. Also ensures system notifications are issued for config errors when `handlr` is not run in a terminal and does some minor refactoring.

Fixes #82