### PR TITLE
fix: fix faulty completions

### DIFF
--- a/build/apps.rs
+++ b/build/apps.rs
@@ -3,6 +3,7 @@
 // because they rely on their own dependencies and so on
 
 use std::error::Error;
+use std::ffi::OsString;
 
 pub struct SystemApps;
 pub struct DesktopEntry {
@@ -11,9 +12,14 @@ pub struct DesktopEntry {
 
 impl SystemApps {
     pub fn get_entries(
-    ) -> Result<impl Iterator<Item = (String, DesktopEntry)>, Box<dyn Error>>
+    ) -> Result<impl Iterator<Item = (OsString, DesktopEntry)>, Box<dyn Error>>
     {
-        let name = "".to_string();
-        Ok(vec![(name.clone(), DesktopEntry { name })].into_iter())
+        Ok(vec![(
+            OsString::new(),
+            DesktopEntry {
+                name: String::new(),
+            },
+        )]
+        .into_iter())
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,6 @@ use clap_complete::{
 #[clap(disable_help_subcommand = true)]
 #[clap(version, about)]
 pub enum Cmd {
-    #[clap(verbatim_doc_comment)]
     /// List default apps and the associated handlers
     ///
     /// Output is formatted as a table with two columns.
@@ -58,12 +57,13 @@ pub enum Cmd {
     /// }
     ///
     /// Where each top-level key has an array with the same scheme as the normal `--json` output
+    #[clap(verbatim_doc_comment)]
     List {
-        #[clap(long)]
         /// Output handler info as json
+        #[clap(long)]
         json: bool,
-        #[clap(long, short)]
         /// Expand wildcards in mimetypes and show global defaults
+        #[clap(long, short)]
         all: bool,
     },
 
@@ -75,8 +75,8 @@ pub enum Cmd {
     /// you will be prompted to select one using `selector` from ~/.config/handlr/handlr.toml.
     /// Otherwise, the default handler will be opened.
     Open {
-        #[clap(required = true, add=ArgValueCompleter::new(PathCompleter::any()))]
         /// Paths/URLs to open
+        #[clap(required = true, add=ArgValueCompleter::new(PathCompleter::any()))]
         paths: Vec<UserPath>,
         #[command(flatten)]
         selector_args: SelectorArgs,
@@ -94,11 +94,11 @@ pub enum Cmd {
     ///
     /// Currently does not support regex handlers.
     Set {
-        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         /// Mimetype or file extension to operate on.
+        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         mime: MimeOrExtension,
-        #[clap(add = ArgValueCompleter::new(autocomplete_desktop_files))]
         /// Desktop file of handler program
+        #[clap(add = ArgValueCompleter::new(autocomplete_desktop_files))]
         handler: DesktopHandler,
     },
 
@@ -111,8 +111,8 @@ pub enum Cmd {
     ///
     /// Currently does not support regex handlers.
     Unset {
-        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         /// Mimetype or file extension to unset the default handler of
+        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         mime: MimeOrExtension,
     },
 
@@ -124,18 +124,17 @@ pub enum Cmd {
     /// you will be prompted to select one using `selector` from ~/.config/handlr/handlr.toml.
     /// Otherwise, the default handler will be opened.
     Launch {
-        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         /// Mimetype or file extension to launch the handler of
+        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         mime: MimeOrExtension,
+        /// Arguments to pass to handler program
         // Not necessarily a path, but completing as a path tends to be the expected "default" behavior
         #[clap(add=ArgValueCompleter::new(PathCompleter::any()))]
-        /// Arguments to pass to handler program
         args: Vec<String>,
         #[command(flatten)]
         selector_args: SelectorArgs,
     },
 
-    #[clap(verbatim_doc_comment)]
     /// Get handler for this mime/extension
     ///
     /// If multiple handlers are set and `enable_selector` is set to true,
@@ -154,12 +153,13 @@ pub enum Cmd {
     ///
     /// Note that when handlr is not being directly output to a terminal, and the handler is a terminal program,
     /// the "cmd" key in the json output will include the command of the `x-scheme-handler/terminal` handler.
+    #[clap(verbatim_doc_comment)]
     Get {
-        #[clap(long)]
         /// Output handler info as json
+        #[clap(long)]
         json: bool,
-        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         /// Mimetype to get the handler of
+        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         mime: MimeOrExtension,
         #[command(flatten)]
         selector_args: SelectorArgs,
@@ -175,11 +175,11 @@ pub enum Cmd {
     /// This subcommand adds secondary handlers that coexist with the default
     /// and does not overwrite existing handlers.
     Add {
-        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         /// Mimetype to add handler to
+        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         mime: MimeOrExtension,
-        #[clap(add = ArgValueCompleter::new(autocomplete_desktop_files))]
         /// Desktop file of handler program
+        #[clap(add = ArgValueCompleter::new(autocomplete_desktop_files))]
         handler: DesktopHandler,
     },
 
@@ -190,15 +190,14 @@ pub enum Cmd {
     /// Literal wildcards (e.g. `text/*`) will be favored over matching mimetypes if present.
     /// Otherwise, mimes matching wildcards (e.g. `text/plain`, etc.) will have their handlers removed.
     Remove {
-        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         /// Mimetype to remove handler from
+        #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         mime: MimeOrExtension,
-        #[clap(add = ArgValueCompleter::new(autocomplete_desktop_files))]
         /// Desktop file of handler program to remove
+        #[clap(add = ArgValueCompleter::new(autocomplete_desktop_files))]
         handler: DesktopHandler,
     },
 
-    #[clap(verbatim_doc_comment)]
     /// Get the mimetype of a given file/URL
     ///
     /// By default, output is in the form of a table that matches file paths/URLs to their mimetypes.
@@ -216,27 +215,28 @@ pub enum Cmd {
     ///   },
     /// ...
     /// ]
+    #[clap(verbatim_doc_comment)]
     Mime {
-        #[clap(required = true, add=ArgValueCompleter::new(PathCompleter::any()))]
         /// File paths/URLs to get the mimetype of
+        #[clap(required = true, add=ArgValueCompleter::new(PathCompleter::any()))]
         paths: Vec<UserPath>,
-        #[clap(long)]
         /// Output mimetype info as json
+        #[clap(long)]
         json: bool,
     },
 }
 
 #[derive(Clone, Args)]
 pub struct SelectorArgs {
-    #[clap(long, short)]
     /// Override the configured selector command
-    pub selector: Option<String>,
     #[clap(long, short)]
+    pub selector: Option<String>,
     /// Enable selector, overrides `enable_selector`
+    #[clap(long, short)]
     pub enable_selector: bool,
+    /// Disable selector, overrides `enable_selector`
     #[clap(long, short)]
     #[clap(overrides_with = "enable_selector")]
-    /// Disable selector, overrides `enable_selector`
     pub disable_selector: bool,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,10 @@ use crate::{
     common::{mime_types, DesktopHandler, MimeOrExtension, UserPath},
 };
 use clap::{builder::StyledStr, Args, Parser};
-use clap_complete::engine::{ArgValueCompleter, CompletionCandidate};
+use clap_complete::{
+    engine::{ArgValueCompleter, CompletionCandidate},
+    PathCompleter,
+};
 
 /// A better xdg-utils
 ///
@@ -72,7 +75,7 @@ pub enum Cmd {
     /// you will be prompted to select one using `selector` from ~/.config/handlr/handlr.toml.
     /// Otherwise, the default handler will be opened.
     Open {
-        #[clap(required = true)]
+        #[clap(required = true, add=ArgValueCompleter::new(PathCompleter::any()))]
         /// Paths/URLs to open
         paths: Vec<UserPath>,
         #[command(flatten)]
@@ -124,6 +127,8 @@ pub enum Cmd {
         #[clap(add = ArgValueCompleter::new(autocomplete_mimes))]
         /// Mimetype or file extension to launch the handler of
         mime: MimeOrExtension,
+        // Not necessarily a path, but completing as a path tends to be the expected "default" behavior
+        #[clap(add=ArgValueCompleter::new(PathCompleter::any()))]
         /// Arguments to pass to handler program
         args: Vec<UserPath>,
         #[command(flatten)]
@@ -212,7 +217,7 @@ pub enum Cmd {
     /// ...
     /// ]
     Mime {
-        #[clap(required = true)]
+        #[clap(required = true, add=ArgValueCompleter::new(PathCompleter::any()))]
         /// File paths/URLs to get the mimetype of
         paths: Vec<UserPath>,
         #[clap(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,7 +130,7 @@ pub enum Cmd {
         // Not necessarily a path, but completing as a path tends to be the expected "default" behavior
         #[clap(add=ArgValueCompleter::new(PathCompleter::any()))]
         /// Arguments to pass to handler program
-        args: Vec<UserPath>,
+        args: Vec<String>,
         #[command(flatten)]
         selector_args: SelectorArgs,
     },

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -79,11 +79,7 @@ impl Config {
 
     /// Given a mime and arguments, launch the associated handler with the arguments
     #[mutants::skip] // Cannot test directly, runs external command
-    pub fn launch_handler(
-        &self,
-        mime: &Mime,
-        args: Vec<UserPath>,
-    ) -> Result<()> {
+    pub fn launch_handler(&self, mime: &Mime, args: Vec<String>) -> Result<()> {
         self.get_handler(mime)?
             .launch(self, args.into_iter().map(|a| a.to_string()).collect())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use clap_complete::CompleteEnv;
 
 #[mutants::skip] // Cannot test directly at the moment
 fn main() -> Result<()> {
-    CompleteEnv::with_factory(|| Cmd::command().name("handlr")).complete();
+    CompleteEnv::with_factory(|| Cmd::command().name("handlr")).completer("handlr").complete();
 
     let mut config = Config::new()?;
     let mut stdout = std::io::stdout().lock();


### PR DESCRIPTION
Fixes broken completions for some subcommands.

Hopefully also obviates the need for downstream maintainers to patch generated completion scripts.

Closes #89.