### PR TITLE
feat: add logging support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ dependencies = [
  "linked-hash-map",
  "once_cell",
  "pin-project",
+ "regex",
  "serde",
  "similar",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "mutants",
  "notify-rust",
  "once_cell",
+ "pipe",
  "regex",
  "serde",
  "serde_ini",
@@ -1625,6 +1626,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pipe"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7b8f27da217eb966df4c58d4159ea939431950ca03cf782c22bd7c5c1d8d75"
+dependencies = [
+ "crossbeam-channel",
+]
 
 [[package]]
 name = "piper"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.7",
  "serde",
 ]
 
@@ -218,6 +218,16 @@ checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeab6a5cdfc795a05538422012f20a5496f050223c91be4e5420bfd13c641fb1"
+dependencies = [
+ "clap",
+ "tracing-core",
 ]
 
 [[package]]
@@ -316,6 +326,21 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "darling"
@@ -644,6 +669,7 @@ version = "0.12.1"
 dependencies = [
  "aho-corasick 0.7.20",
  "clap",
+ "clap-verbosity-flag",
  "clap_complete",
  "clap_mangen",
  "confy",
@@ -667,6 +693,10 @@ dependencies = [
  "similar-asserts",
  "tabled",
  "thiserror",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "tracing-unwrap",
  "url",
  "wildmatch",
  "xdg",
@@ -968,6 +998,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1086,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1157,6 +1206,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "papergrid"
@@ -1280,8 +1335,17 @@ checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick 1.1.3",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1292,8 +1356,14 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick 1.1.3",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1514,6 +1584,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1626,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -1682,6 +1767,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,21 +1889,84 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.32"
+name = "tracing-appender"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-unwrap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e33415be97f5ae70322d6fefc696bbc08887d8835400d6c77f059469b30354"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]
@@ -1875,6 +2033,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,145 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock",
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+ "tracing",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if 1.0.0",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +290,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bstr"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +357,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -263,7 +430,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -287,6 +454,15 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "confy"
@@ -363,7 +539,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.70",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -374,7 +550,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -395,7 +571,7 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -462,6 +638,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.6.0",
+ "objc2",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,7 +683,28 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -508,6 +721,27 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -558,7 +792,7 @@ dependencies = [
  "memchr",
  "strsim",
  "textdistance",
- "thiserror",
+ "thiserror 1.0.61",
  "xdg",
 ]
 
@@ -576,6 +810,25 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-sink"
@@ -656,7 +909,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.6",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -682,6 +935,7 @@ dependencies = [
  "mime",
  "mime-db",
  "mutants",
+ "notify-rust",
  "once_cell",
  "regex",
  "serde",
@@ -692,7 +946,7 @@ dependencies = [
  "shlex",
  "similar-asserts",
  "tabled",
- "thiserror",
+ "thiserror 1.0.61",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -711,9 +965,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -726,6 +980,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -815,7 +1075,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -856,12 +1116,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -943,9 +1203,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libredox"
@@ -989,6 +1249,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b95dfb34071d1592b45622bf93e315e3a72d414b6782aca9a015c12bec367ef"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1283,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1079,6 +1360,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1380,20 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -1131,6 +1439,45 @@ dependencies = [
  "block",
  "objc",
  "objc_id",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.6.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1180,7 +1527,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1208,6 +1555,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1580,12 @@ dependencies = [
  "fnv",
  "unicode-width",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "percent-encoding"
@@ -1247,7 +1610,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1263,16 +1626,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -1308,6 +1706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,7 +1731,7 @@ checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1506,7 +1913,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1542,6 +1949,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,7 +1981,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1580,7 +1998,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1597,6 +2015,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "similar"
@@ -1644,6 +2071,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1723,6 +2156,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml",
+ "thiserror 2.0.12",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
 name = "temp-dir"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,7 +2197,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1763,7 +2217,18 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1846,7 +2311,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1882,6 +2347,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap 2.9.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,7 +2387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.61",
  "time",
  "tracing-subscriber",
 ]
@@ -1918,7 +2400,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1974,6 +2456,17 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
+]
 
 [[package]]
 name = "unicase"
@@ -2094,7 +2587,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -2128,7 +2621,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2178,12 +2671,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2242,6 +2837,24 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2335,6 +2948,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,4 +2983,105 @@ dependencies = [
  "mime",
  "nom",
  "unicase",
+]
+
+[[package]]
+name = "zbus"
+version = "5.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.59.0",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e7e5eec1550f747e71a058df81a9a83813ba0f6a95f39c4e218bdc7ba366a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d30786f75e393ee63a21de4f9074d4c038d52c5b1bb4471f955db249f9dffb1"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75fda702cd42d735ccd48117b1630432219c0e9616bf6cb0f8350844ee4d9580"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "static_assertions",
+ "syn 2.0.87",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = "1.0"
 serde_regex = "1.1.0"
 enum_dispatch = "0.3.13"
 freedesktop-desktop-entry = "0.6.1"
-derive_more = { version = "0.99.18", default-features = false, features = ["deref", "deref_mut"] }
+derive_more = { version = "0.99.18", default-features = false, features = ["deref", "deref_mut", "display"] }
 serde_ini = "0.2.0"
 serde_with = "3.8.3"
 wildmatch = "2.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ name = "handlr"
 path = "src/main.rs"
 
 [dev-dependencies]
-insta = "1.42.2"
+insta = { version = "1.42.2", features = ["filters"] }
 insta-cmd = "0.6.0"
 similar-asserts = "1.7.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ path = "src/main.rs"
 [dev-dependencies]
 insta = { version = "1.42.2", features = ["filters"] }
 insta-cmd = "0.6.0"
+pipe = "0.4.0"
 similar-asserts = "1.7.0"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing-appender = "0.2.3"
 tracing-unwrap = "1.0.1"
 clap-verbosity-flag = { version = "3.0.3", default-features = false, features = ["tracing"] }
+notify-rust = "4.11.7"
 
 [[bin]]
 name = "handlr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ serde_with = "3.8.3"
 wildmatch = "2.3.4"
 mutants = "0.0.3"
 clap_complete = { version = "4.5.33", features = ["unstable-dynamic"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-appender = "0.2.3"
+tracing-unwrap = "1.0.1"
+clap-verbosity-flag = { version = "3.0.3", default-features = false, features = ["tracing"] }
 
 [[bin]]
 name = "handlr"
@@ -50,6 +55,7 @@ clap_complete = { version = "4.5.33", features = ["unstable-dynamic"] }
 clap_mangen = "0.2.20"
 mime-db = "1.3.0"
 mutants = "0.0.3"
+clap-verbosity-flag = { version = "3.0.3", default-features = false, features = ["tracing"] }
 
 [profile.release]
 opt-level = "z"

--- a/README.md
+++ b/README.md
@@ -151,6 +151,19 @@ See [`clap_complete`'s documentation](https://docs.rs/clap_complete/latest/clap_
 > [!NOTE]
 > This currently relies on unstable features of the `clap_complete` crate and may potentially change in the future.
 
+## Logging
+
+Since v0.13.0, `handlr-regex` supports logs to help with troubleshooting.
+
+Logs are output in three ways:
+- stderr
+- notifications (only when neither running in an interactive terminal nor with `--disable-notifications` active)
+- log file at `$XDG_CACHE_HOME/handlr/handlr.log`
+
+By default, for stderr and notifications, only warning and error logs are shown. This can be configured with `--verbose` and `--quiet` as well as with `$RUST_LOG`. All logs are printed to the log file regardless. 
+
+For more information on the syntax for `$RUST_LOG`, see [the documentation for `tracing_subscriber::Envfilter`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives)
+
 ## Screenshots
 
 <table><tr><td>

--- a/src/apps/system.rs
+++ b/src/apps/system.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use mime::Mime;
 use std::{collections::BTreeMap, convert::TryFrom, ffi::OsString};
+use tracing::debug;
 
 #[derive(Debug, Default, Clone)]
 pub struct SystemApps {
@@ -17,12 +18,25 @@ pub struct SystemApps {
 impl SystemApps {
     /// Get the list of handlers associated with a given mime
     pub fn get_handlers(&self, mime: &Mime) -> Option<DesktopList> {
-        Some(self.associations.get(mime)?.clone())
+        let associations = self.associations.get(mime);
+
+        if associations.is_none() {
+            debug!("No installed handlers found for `{}`", mime);
+        } else {
+            debug!(
+                "Installed handlers found for `{}`: {}",
+                mime, associations?
+            );
+        }
+
+        Some(associations?.clone())
     }
 
     /// Get the primary of handler associated with a given mime
     pub fn get_handler(&self, mime: &Mime) -> Option<DesktopHandler> {
-        Some(self.get_handlers(mime)?.front()?.clone())
+        let handler = self.get_handlers(mime)?.front()?.clone();
+        debug!("Installed handler chosen for `{}`: {}", mime, handler);
+        Some(handler)
     }
 
     /// Get all system-level desktop entries on the system

--- a/src/apps/user.rs
+++ b/src/apps/user.rs
@@ -77,6 +77,9 @@ impl MimeApps {
         handler: &DesktopHandler,
         expand_wildcards: bool,
     ) -> Result<()> {
+        // Warn the user if the given handler does not exist
+        handler.warn_if_invalid();
+
         if expand_wildcards {
             let wildcard = WildMatch::new(mime.as_ref());
             mime_types()
@@ -105,6 +108,9 @@ impl MimeApps {
         handler: &DesktopHandler,
         expand_wildcards: bool,
     ) -> Result<()> {
+        // Warn the user if the given handler does not exist
+        handler.warn_if_invalid();
+
         if expand_wildcards {
             let wildcard = WildMatch::new(mime.as_ref());
             mime_types()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use clap_complete::{
     engine::{ArgValueCompleter, CompletionCandidate},
     PathCompleter,
 };
+use clap_verbosity_flag::{Verbosity, WarnLevel};
 use std::{ffi::OsStr, fmt::Write, io::IsTerminal};
 
 /// A better xdg-utils
@@ -31,6 +32,9 @@ pub struct Cli {
     /// Overrides whether or not to behave as if the output is an interactive terminal
     #[clap(global = true, long = "force-terminal-output", short = 't')]
     terminal_output: Option<bool>,
+
+    #[command(flatten)]
+    pub verbosity: Verbosity<WarnLevel>,
 }
 
 #[allow(dead_code)] // These are left unused in the build script that includes this
@@ -41,7 +45,7 @@ impl Cli {
     }
 
     pub fn show_notifications(&self) -> bool {
-        self.terminal_output() && self.enable_notifications
+        !self.terminal_output() && self.enable_notifications
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -271,7 +271,7 @@ fn autocomplete_mimes(current: &OsStr) -> Vec<CompletionCandidate> {
 #[mutants::skip] // Cannot test directly, relies on system state
 fn autocomplete_desktop_files(current: &OsStr) -> Vec<CompletionCandidate> {
     SystemApps::get_entries()
-        .expect("Could not get system desktop entries")
+        .expect("handlr error: Could not get system desktop entries")
         .filter(|(path, _)| {
             path.to_string_lossy()
                 .starts_with(current.to_string_lossy().as_ref())
@@ -279,7 +279,7 @@ fn autocomplete_desktop_files(current: &OsStr) -> Vec<CompletionCandidate> {
         .map(|(path, entry)| {
             let mut name = StyledStr::new();
             write!(name, "{}", entry.name)
-                .expect("Could not write desktop entry name");
+                .expect("handlr error: Could not write desktop entry name");
             CompletionCandidate::new(path).help(Some(name))
         })
         .collect()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,12 @@ use std::{ffi::OsStr, fmt::Write, io::IsTerminal};
 /// Based on handlr at <https://github.com/chmln/handlr>
 ///
 /// Regular expression handlers inspired by mimeo at <https://xyne.dev/projects/mimeo/>
+///
+/// Mime associations file location: ~/.config/mimeapps.list
+///
+/// Config file location: ~/.config/handlr/handlr.toml
+///
+/// Log file location: ~/.cache/handlr/handlr.log
 #[deny(missing_docs)]
 #[derive(Parser)]
 #[clap(disable_help_subcommand = true)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,11 +18,11 @@ use std::{ffi::OsStr, fmt::Write, io::IsTerminal};
 ///
 /// Regular expression handlers inspired by mimeo at <https://xyne.dev/projects/mimeo/>
 ///
-/// Mime associations file location: ~/.config/mimeapps.list
+/// Mime associations file location: $XDG_CONFIG_HOME/mimeapps.list
 ///
-/// Config file location: ~/.config/handlr/handlr.toml
+/// Config file location: $XDG_CONFIG_HOME/handlr/handlr.toml
 ///
-/// Log file location: ~/.cache/handlr/handlr.log
+/// Log file location: $XDG_CACHE_HOME/handlr/handlr.log
 #[deny(missing_docs)]
 #[derive(Parser)]
 #[clap(disable_help_subcommand = true)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ use clap_complete::{
     engine::{ArgValueCompleter, CompletionCandidate},
     PathCompleter,
 };
-use std::{ffi::OsStr, fmt::Write};
+use std::{ffi::OsStr, fmt::Write, io::IsTerminal};
 
 /// A better xdg-utils
 ///
@@ -26,11 +26,23 @@ pub struct Cli {
 
     /// Disable notifications on error
     #[clap(global = true, long = "disable-notifications", short = 'n', action = ArgAction::SetFalse)]
-    pub enable_notifications: bool,
+    enable_notifications: bool,
 
     /// Overrides whether or not to behave as if the output is an interactive terminal
     #[clap(global = true, long = "force-terminal-output", short = 't')]
-    pub terminal_output: Option<bool>,
+    terminal_output: Option<bool>,
+}
+
+#[allow(dead_code)] // These are left unused in the build script that includes this
+impl Cli {
+    pub fn terminal_output(&self) -> bool {
+        self.terminal_output
+            .unwrap_or(std::io::stdout().is_terminal())
+    }
+
+    pub fn show_notifications(&self) -> bool {
+        self.terminal_output() && self.enable_notifications
+    }
 }
 
 #[deny(missing_docs)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -309,10 +309,39 @@ fn autocomplete_desktop_files(current: &OsStr) -> Vec<CompletionCandidate> {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use crate::error::Result;
+
     use super::*;
 
     #[test]
     fn test_autocomplete_mimes() {
         insta::assert_debug_snapshot!(autocomplete_mimes(OsStr::new("")));
+    }
+
+    #[test]
+    fn test_show_notifications() -> Result<()> {
+        let mut cli = Cli {
+            command: Cmd::Unset {
+                mime: MimeType::from_str("fake/mime")?,
+            },
+            enable_notifications: true,
+            terminal_output: Some(false),
+            verbosity: Verbosity::default(),
+        };
+
+        assert!(cli.show_notifications());
+
+        cli.terminal_output = Some(true);
+        assert!(!cli.show_notifications());
+
+        cli.enable_notifications = false;
+        assert!(!cli.show_notifications());
+
+        cli.terminal_output = Some(true);
+        assert!(!cli.show_notifications());
+
+        Ok(())
     }
 }

--- a/src/common/desktop_entry.rs
+++ b/src/common/desktop_entry.rs
@@ -16,6 +16,7 @@ use std::{
     process::{Command, Stdio},
     str::FromStr,
 };
+use tracing::debug;
 
 /// Represents a desktop entry file for an application
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -72,6 +73,7 @@ impl DesktopEntry {
     fn exec_inner(&self, config: &Config, args: Vec<String>) -> Result<()> {
         let mut cmd = {
             let (cmd, args) = self.get_cmd(config, args)?;
+            debug!("Executing program \"{}\" with args: {:?}", cmd, args);
             let mut cmd = Command::new(cmd);
             cmd.args(args);
             cmd

--- a/src/common/handler.rs
+++ b/src/common/handler.rs
@@ -14,6 +14,7 @@ use std::{
     path::PathBuf,
     str::FromStr,
 };
+use tracing::warn;
 
 /// Represents a program or command that is used to open a file
 #[enum_dispatch(Handleable)]
@@ -93,6 +94,13 @@ impl DesktopHandler {
     #[mutants::skip] // Cannot test directly, runs command
     pub fn launch(&self, config: &Config, args: Vec<String>) -> Result<()> {
         self.get_entry()?.exec(config, ExecMode::Launch, args)
+    }
+
+    /// Issue a warning if the given handler is invalid
+    pub fn warn_if_invalid(&self) {
+        if let Err(e) = self.get_entry() {
+            warn!("The desktop entry `{}` is invalid: {}", self, e);
+        }
     }
 }
 

--- a/src/common/mime_types.rs
+++ b/src/common/mime_types.rs
@@ -2,6 +2,7 @@ use crate::error::{Error, Result};
 use derive_more::Deref;
 use mime::Mime;
 use std::{convert::TryFrom, path::Path, str::FromStr};
+use tracing_unwrap::{OptionExt, ResultExt};
 use url::Url;
 
 /// A mime derived from a path or URL
@@ -15,7 +16,7 @@ impl MimeType {
             .get_mime_types_from_file_name(ext)
             .into_iter()
             .nth(0)
-            .expect("handlr: xdg_mime::get_mime_types_from_file_type should always return a non-empty Vec<Mime>")
+            .expect_or_log("The function xdg_mime::get_mime_types_from_file_type should always return a non-empty Vec<Mime>")
         {
             // If the file extension is ambiguous, then error
             // Otherwise, the user may not expect this mimetype being assigned
@@ -49,7 +50,7 @@ impl TryFrom<&Path> for MimeType {
         if mime
             == "application/x-zerosize"
                 .parse::<Mime>()
-                .expect("handlr: hardcoded mime should be valid")
+                .expect_or_log("Hardcoded mime should be valid")
         {
             mime = guess.path(path).guess().mime_type().clone();
         }

--- a/src/common/path.rs
+++ b/src/common/path.rs
@@ -2,6 +2,7 @@ use crate::{
     common::{render_table, MimeType},
     error::{Error, Result},
 };
+use itertools::Itertools;
 use mime::Mime;
 use serde::Serialize;
 use std::{
@@ -12,6 +13,7 @@ use std::{
     str::FromStr,
 };
 use tabled::Tabled;
+use tracing::{debug, info};
 use url::Url;
 
 #[derive(Debug, Clone)]
@@ -82,6 +84,15 @@ pub fn mime_table<W: Write>(
     output_json: bool,
     terminal_output: bool,
 ) -> Result<()> {
+    info!(
+        "Printing mime information for paths: [{}]",
+        paths
+            .iter()
+            .format_with(", ", |str, f| f(&format!("\"{}\"", str)))
+            .to_string()
+    );
+    debug!("JSON output: {}", output_json);
+
     let rows = paths
         .iter()
         .map(UserPathTable::new)
@@ -95,6 +106,7 @@ pub fn mime_table<W: Write>(
 
     writeln!(writer, "{table}")?;
 
+    info!("Finished printing mime information");
     Ok(())
 }
 

--- a/src/config/config_file.rs
+++ b/src/config/config_file.rs
@@ -4,6 +4,7 @@ use crate::{
     error::Result,
 };
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 /// The config file
 #[derive(Debug, Serialize, Deserialize)]
@@ -53,11 +54,14 @@ impl ConfigFile {
     /// Currently assumes the config file will never be saved to
     pub fn override_selector(&mut self, selector_args: SelectorArgs) {
         if let Some(selector) = selector_args.selector {
+            debug!("Overriding selector command: {}", selector);
             self.selector = selector;
         }
 
         self.enable_selector = (self.enable_selector
             || selector_args.enable_selector)
             && !selector_args.disable_selector;
+
+        debug!("Selector enabled: {}", self.enable_selector);
     }
 }

--- a/src/config/config_file.rs
+++ b/src/config/config_file.rs
@@ -17,8 +17,6 @@ pub struct ConfigFile {
     pub term_exec_args: Option<String>,
     /// Whether to expand wildcards when saving mimeapps.list
     pub expand_wildcards: bool,
-    /// Whether to show notifications on errors
-    pub enable_notifications: bool,
     /// Regex handlers
     // NOTE: Serializing is only necessary for generating a default config file
     #[serde(skip_serializing)]
@@ -34,7 +32,6 @@ impl Default for ConfigFile {
             // Unfortunately, messes up emulators that don't accept it
             term_exec_args: Some("-e".into()),
             expand_wildcards: false,
-            enable_notifications: true,
             handlers: Default::default(),
         }
     }

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -1,14 +1,17 @@
 // FIXME
 #![allow(clippy::mutable_key_type)]
 
+use itertools::Itertools;
 use mime::Mime;
 use serde::Serialize;
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
+    fmt::Display,
     io::Write,
     str::FromStr,
 };
 use tabled::Tabled;
+use tracing::{debug, info};
 
 use crate::{
     apps::{DesktopList, MimeApps, SystemApps},
@@ -51,7 +54,13 @@ impl Config {
     pub fn get_handler(&self, mime: &Mime) -> Result<DesktopHandler> {
         match self.mime_apps.get_handler_from_user(mime, &self.config) {
             Err(e) if matches!(e, Error::Cancelled) => Err(e),
-            h => h.or_else(|_| self.get_handler_from_added_associations(mime)),
+            h => h
+                .inspect(|_| {
+                    info!("Match found for `{}` in mimeapps.list Default Associations", mime);
+                })
+                .or_else(|_|{
+                    info!("No match for `{}` in mimeapps.list Default Associations", mime);
+                    self.get_handler_from_added_associations(mime)}),
         }
     }
 
@@ -64,18 +73,33 @@ impl Config {
         self.mime_apps
             .added_associations
             .get(mime)
+            .inspect(|_|
+                info!("Found matching entry for `{}` in mimeapps.list Added Associations", mime)
+            )
             .map_or_else(
-                || self.system_apps.get_handler(mime),
+                || {
+                    info!("No matching entries for `{}` in mimeapps.list Added Associations", mime);
+                    self.system_apps.get_handler(mime)
+                },
                 |h| h.front().cloned(),
             )
-            .ok_or_else(|| Error::NotFound(mime.to_string()))
+            .ok_or_else(|| {
+                info!("No matching installed handlers found for `{}`", mime);
+                Error::NotFound(mime.to_string())
+            })
     }
 
     /// Given a mime and arguments, launch the associated handler with the arguments
     #[mutants::skip] // Cannot test directly, runs external command
     pub fn launch_handler(&self, mime: &Mime, args: Vec<String>) -> Result<()> {
+        info!(
+            "Launching handler for `{}` with arguments: {:?}",
+            mime, args
+        );
         self.get_handler(mime)?
-            .launch(self, args.into_iter().map(|a| a.to_string()).collect())
+            .launch(self, args.into_iter().map(|a| a.to_string()).collect())?;
+        info!("Finished launching handler");
+        Ok(())
     }
 
     /// Get the handler associated with a given mime
@@ -85,6 +109,9 @@ impl Config {
         mime: &Mime,
         output_json: bool,
     ) -> Result<()> {
+        info!("Showing handler for `{}`", mime);
+        debug!("JSON output: {}", output_json);
+
         let handler = self.get_handler(mime)?;
 
         let output = if output_json {
@@ -101,6 +128,8 @@ impl Config {
             handler.to_string()
         };
         writeln!(writer, "{output}")?;
+
+        info!("Finished showing handler");
         Ok(())
     }
 
@@ -111,12 +140,17 @@ impl Config {
         mime: &Mime,
         handler: &DesktopHandler,
     ) -> Result<()> {
+        info!("Setting `{}` as handler for `{}`", handler, mime);
+
         self.mime_apps.set_handler(
             mime,
             handler,
             self.config.expand_wildcards,
         )?;
-        self.mime_apps.save()
+        self.mime_apps.save()?;
+
+        info!("Finished setting handler");
+        Ok(())
     }
 
     /// Add a handler to an existing default application association
@@ -126,22 +160,41 @@ impl Config {
         mime: &Mime,
         handler: &DesktopHandler,
     ) -> Result<()> {
+        info!("Adding {} to list of handlers for `{}`", handler, mime);
+
         self.mime_apps.add_handler(
             mime,
             handler,
             self.config.expand_wildcards,
         )?;
-        self.mime_apps.save()
+        self.mime_apps.save()?;
+
+        info!("Finished adding handler");
+        Ok(())
     }
 
     /// Open the given paths with their respective handlers
     #[mutants::skip] // Cannot test directly, runs external commands
     pub fn open_paths(&self, paths: &[UserPath]) -> Result<()> {
+        fn format_paths<T: Display>(paths: &[T]) -> String {
+            format!(
+                "[{}]",
+                paths
+                    .iter()
+                    .format_with(", ", |str, f| f(&format!("\"{}\"", str)))
+            )
+        }
+
+        info!("Started opening paths: {}", format_paths(paths));
+
         for (handler, paths) in
             self.assign_files_to_handlers(paths)?.into_iter()
         {
+            debug!("Opening {} using `{}`", format_paths(&paths), handler);
             handler.open(self, paths)?;
         }
+
+        info!("Finished opening paths");
 
         Ok(())
     }
@@ -166,8 +219,10 @@ impl Config {
     /// Get the handler associated with a given path
     fn get_handler_from_path(&self, path: &UserPath) -> Result<Handler> {
         Ok(if let Ok(handler) = self.config.get_regex_handler(path) {
+            info!("Using regex handler for `{}`", path);
             handler.into()
         } else {
+            info!("No matching regex handlers found for `{}`", path);
             self.get_handler(&path.get_mime()?)?.into()
         })
     }
@@ -202,6 +257,9 @@ impl Config {
         detailed: bool,
         output_json: bool,
     ) -> Result<()> {
+        info!("Printing associations");
+        debug!("JSON output: {}", output_json);
+
         let mimeapps_table = MimeAppsTable::new(
             &self.mime_apps,
             &self.system_apps,
@@ -259,15 +317,19 @@ impl Config {
             )?
         }
 
+        info!("Finished printing associations");
         Ok(())
     }
 
     /// Entirely remove a given mime's default application association
     pub fn unset_handler(&mut self, mime: &Mime) -> Result<()> {
+        info!("Unsetting handler for `{}`", mime);
+
         if self.mime_apps.unset_handler(mime).is_some() {
             self.mime_apps.save()?
         }
 
+        info!("Finished unsetting handler");
         Ok(())
     }
 
@@ -277,10 +339,16 @@ impl Config {
         mime: &Mime,
         handler: &DesktopHandler,
     ) -> Result<()> {
+        info!(
+            "Removing `{}` from list of handlers for `{}`",
+            handler, mime
+        );
+
         if self.mime_apps.remove_handler(mime, handler).is_some() {
             self.mime_apps.save()?
         }
 
+        info!("Finished removing handler");
         Ok(())
     }
 

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -435,11 +435,14 @@ impl MimeAppsTable {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Read;
+
+    use crate::testing;
+
     use super::*;
     use similar_asserts::assert_eq;
 
-    #[test]
-    fn wildcard_mimes() -> Result<()> {
+    crate::logs_snapshot_test!(wildcard_mimes, {
         let mut config = Config::default();
         config.add_handler(
             &Mime::from_str("video/*")?,
@@ -468,9 +471,7 @@ mod tests {
                 .to_string(),
             "brave.desktop"
         );
-
-        Ok(())
-    }
+    });
 
     #[test]
     fn complex_wildcard_mimes() -> Result<()> {
@@ -571,40 +572,31 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn print_handlers_default() -> Result<()> {
+    crate::logs_snapshot_test!(print_handlers_default, {
         let mut buffer = Vec::new();
         print_handlers_test(&mut buffer, false, false, true)?;
         insta::assert_snapshot!(String::from_utf8(buffer)?);
-        Ok(())
-    }
+    });
 
-    #[test]
-    fn print_handlers_piped() -> Result<()> {
+    crate::logs_snapshot_test!(print_handlers_piped, {
         let mut buffer = Vec::new();
         print_handlers_test(&mut buffer, false, false, false)?;
         insta::assert_snapshot!(String::from_utf8(buffer)?);
-        Ok(())
-    }
+    });
 
-    #[test]
-    fn print_handlers_detailed() -> Result<()> {
+    crate::logs_snapshot_test!(print_handlers_detailed, {
         let mut buffer = Vec::new();
         print_handlers_test(&mut buffer, true, false, true)?;
         insta::assert_snapshot!(String::from_utf8(buffer)?);
-        Ok(())
-    }
+    });
 
-    #[test]
-    fn print_handlers_detailed_piped() -> Result<()> {
+    crate::logs_snapshot_test!(print_handlers_detailed_piped, {
         let mut buffer = Vec::new();
         print_handlers_test(&mut buffer, true, false, false)?;
         insta::assert_snapshot!(String::from_utf8(buffer)?);
-        Ok(())
-    }
+    });
 
-    #[test]
-    fn print_handlers_json() -> Result<()> {
+    crate::logs_snapshot_test!(print_handlers_json, {
         // NOTE: both calls should have the same result
         // JSON output and terminal output
         let mut buffer = Vec::new();
@@ -615,12 +607,9 @@ mod tests {
         let mut buffer = Vec::new();
         print_handlers_test(&mut buffer, false, true, false)?;
         insta::assert_snapshot!(String::from_utf8(buffer)?);
+    });
 
-        Ok(())
-    }
-
-    #[test]
-    fn print_handlers_detailed_json() -> Result<()> {
+    crate::logs_snapshot_test!(print_handlers_detailed_json, {
         // NOTE: both calls should have the same result
         // JSON output and terminal output
         let mut buffer = Vec::new();
@@ -631,12 +620,9 @@ mod tests {
         let mut buffer = Vec::new();
         print_handlers_test(&mut buffer, true, true, false)?;
         insta::assert_snapshot!(String::from_utf8(buffer)?);
+    });
 
-        Ok(())
-    }
-
-    #[test]
-    fn terminal_command_set() -> Result<()> {
+    crate::logs_snapshot_test!(terminal_command_set, {
         let mut config = Config::default();
 
         config.add_handler(
@@ -647,12 +633,9 @@ mod tests {
         )?;
 
         assert_eq!(config.terminal()?, "wezterm start --cwd . -e");
+    });
 
-        Ok(())
-    }
-
-    #[test]
-    fn terminal_command_fallback() -> Result<()> {
+    crate::logs_snapshot_test!(terminal_command_fallback, {
         let mut config = Config::default();
 
         config
@@ -662,9 +645,7 @@ mod tests {
             )?);
 
         assert_eq!(config.terminal()?, "wezterm start --cwd . -e");
-
-        Ok(())
-    }
+    });
 
     fn test_show_handler<W: Write>(
         writer: &mut W,
@@ -695,42 +676,31 @@ mod tests {
         Ok(())
     }
 
-    #[test]
     // NOTE: result will begin with tests/assets/, which is normal ONLY for tests
-    fn show_handler() -> Result<()> {
+    crate::logs_snapshot_test!(show_handler, {
         let mut buffer = Vec::new();
         test_show_handler(&mut buffer, false, false)?;
-        println!("{}", String::from_utf8(buffer.clone())?);
         insta::assert_snapshot!(String::from_utf8(buffer)?);
-        Ok(())
-    }
+    });
 
-    #[test]
-    fn show_handler_json() -> Result<()> {
+    crate::logs_snapshot_test!(show_handler_json, {
         let mut buffer = Vec::new();
         test_show_handler(&mut buffer, true, false)?;
-        println!("{}", String::from_utf8(buffer.clone())?);
         insta::assert_snapshot!(String::from_utf8(buffer)?);
-        Ok(())
-    }
+    });
 
-    #[test]
     // NOTE: result will begin with tests/, which is normal ONLY for tests
-    fn show_handler_terminal() -> Result<()> {
+    crate::logs_snapshot_test!(show_handler_terminal, {
         let mut buffer = Vec::new();
         test_show_handler(&mut buffer, false, true)?;
-        println!("{}", String::from_utf8(buffer.clone())?);
         insta::assert_snapshot!(String::from_utf8(buffer)?);
-        Ok(())
-    }
-    #[test]
-    fn show_handler_json_terminal() -> Result<()> {
+    });
+
+    crate::logs_snapshot_test!(show_handler_json_terminal, {
         let mut buffer = Vec::new();
         test_show_handler(&mut buffer, true, true)?;
-        println!("{}", String::from_utf8(buffer.clone())?);
         insta::assert_snapshot!(String::from_utf8(buffer)?);
-        Ok(())
-    }
+    });
 
     fn test_add_handlers(config: &mut Config) -> Result<()> {
         config.add_handler(
@@ -815,48 +785,31 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn add_and_remove_handlers() -> Result<()> {
+    crate::logs_snapshot_test!(add_and_remove_handlers, {
         let mut config = Config::default();
-
         test_add_handlers(&mut config)?;
         test_remove_handlers(&mut config)?;
+    });
 
-        Ok(())
-    }
-
-    #[test]
-    fn set_and_unset_handlers() -> Result<()> {
+    crate::logs_snapshot_test!(set_and_unset_handlers, {
         let mut config = Config::default();
-
         test_set_handlers(&mut config)?;
         test_unset_handlers(&mut config)?;
+    });
 
-        Ok(())
-    }
-
-    #[test]
-    fn add_and_unset_handlers() -> Result<()> {
+    crate::logs_snapshot_test!(add_and_unset_handlers, {
         let mut config = Config::default();
-
         test_add_handlers(&mut config)?;
         test_unset_handlers(&mut config)?;
+    });
 
-        Ok(())
-    }
-
-    #[test]
-    fn set_and_remove_handlers() -> Result<()> {
+    crate::logs_snapshot_test!(set_and_remove_handlers, {
         let mut config = Config::default();
-
         test_set_handlers(&mut config)?;
         test_remove_handlers(&mut config)?;
+    });
 
-        Ok(())
-    }
-
-    #[test]
-    fn override_selector() -> Result<()> {
+    crate::logs_snapshot_test!(override_selector, {
         let mut config = Config::default();
 
         // Ensure defaults are as expected just in case
@@ -883,12 +836,9 @@ mod tests {
             "fuzzel --dmenu --prompt='Open With: '"
         );
         assert_eq!(config.config.enable_selector, false);
+    });
 
-        Ok(())
-    }
-
-    #[test]
-    fn dont_override_selector() -> Result<()> {
+    crate::logs_snapshot_test!(dont_override_selector, {
         // NOTE: `enable_selector` and `disable_selector` should not both be true in practice anyways
 
         let mut config = Config::default();
@@ -935,12 +885,9 @@ mod tests {
 
         assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");
         assert_eq!(config.config.enable_selector, true);
+    });
 
-        Ok(())
-    }
-
-    #[test]
-    fn properly_assign_files_to_handlers() -> Result<()> {
+    crate::logs_snapshot_test!(properly_assign_files_to_handlers, {
         let mut config = Config::default();
         config.add_handler(
             &Mime::from_str("image/png")?,
@@ -998,7 +945,5 @@ mod tests {
             ])?,
             expected_handlers
         );
-
-        Ok(())
-    }
+    });
 }

--- a/src/config/snapshots/handlr__config__main_config__tests__add_and_remove_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__add_and_remove_handlers.snap
@@ -1,0 +1,39 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding Helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `Helix.desktop` is invalid: Malformed desktop entry at Helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 2
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Removing `Helix.desktop` from list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished removing handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Removing `nvim.desktop` from list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: <None>
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished removing handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: ;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 0
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No match for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching entries for `text/plain` in mimeapps.list Added Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::system[0m[2m:[0m No installed handlers found for `text/plain`
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching installed handlers found for `text/plain`

--- a/src/config/snapshots/handlr__config__main_config__tests__add_and_unset_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__add_and_unset_handlers.snap
@@ -1,0 +1,30 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding Helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `Helix.desktop` is invalid: Malformed desktop entry at Helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 2
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Unsetting handler for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: <None>
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished unsetting handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m No handlers configured for `text/plain` in mimeapps.list Default associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No match for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching entries for `text/plain` in mimeapps.list Added Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::system[0m[2m:[0m No installed handlers found for `text/plain`
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching installed handlers found for `text/plain`

--- a/src/config/snapshots/handlr__config__main_config__tests__dont_override_selector.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__dont_override_selector.snap
@@ -1,0 +1,8 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::config_file[0m[2m:[0m Selector enabled: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::config_file[0m[2m:[0m Selector enabled: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::config_file[0m[2m:[0m Selector enabled: true
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::config_file[0m[2m:[0m Selector enabled: true

--- a/src/config/snapshots/handlr__config__main_config__tests__override_selector.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__override_selector.snap
@@ -1,0 +1,8 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::config_file[0m[2m:[0m Overriding selector command: fzf
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::config_file[0m[2m:[0m Selector enabled: true
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::config_file[0m[2m:[0m Overriding selector command: fuzzel --dmenu --prompt='Open With: '
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::config_file[0m[2m:[0m Selector enabled: false

--- a/src/config/snapshots/handlr__config__main_config__tests__print_handlers_default-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__print_handlers_default-2.snap
@@ -1,0 +1,47 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/mp4`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/mp4`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/asdf`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/asdf`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding brave.desktop to list of handlers for `video/webm`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `brave.desktop` is invalid: Malformed desktop entry at brave.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/webm`: brave.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `helix.desktop` is invalid: Malformed desktop entry at helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding kakoune.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `kakoune.desktop` is invalid: Malformed desktop entry at kakoune.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;kakoune.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.oasis.opendocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.oasis.opendocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.openxmlformats-officedocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.openxmlformats-officedocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Printing associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: false
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished printing associations

--- a/src/config/snapshots/handlr__config__main_config__tests__print_handlers_detailed-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__print_handlers_detailed-2.snap
@@ -1,0 +1,47 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/mp4`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/mp4`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/asdf`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/asdf`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding brave.desktop to list of handlers for `video/webm`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `brave.desktop` is invalid: Malformed desktop entry at brave.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/webm`: brave.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `helix.desktop` is invalid: Malformed desktop entry at helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding kakoune.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `kakoune.desktop` is invalid: Malformed desktop entry at kakoune.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;kakoune.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.oasis.opendocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.oasis.opendocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.openxmlformats-officedocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.openxmlformats-officedocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Printing associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: false
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished printing associations

--- a/src/config/snapshots/handlr__config__main_config__tests__print_handlers_detailed_json-3.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__print_handlers_detailed_json-3.snap
@@ -1,0 +1,90 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/mp4`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/mp4`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/asdf`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/asdf`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding brave.desktop to list of handlers for `video/webm`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `brave.desktop` is invalid: Malformed desktop entry at brave.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/webm`: brave.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `helix.desktop` is invalid: Malformed desktop entry at helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding kakoune.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `kakoune.desktop` is invalid: Malformed desktop entry at kakoune.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;kakoune.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.oasis.opendocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.oasis.opendocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.openxmlformats-officedocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.openxmlformats-officedocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Printing associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: true
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished printing associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/mp4`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/mp4`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/asdf`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/asdf`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding brave.desktop to list of handlers for `video/webm`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `brave.desktop` is invalid: Malformed desktop entry at brave.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/webm`: brave.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `helix.desktop` is invalid: Malformed desktop entry at helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding kakoune.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `kakoune.desktop` is invalid: Malformed desktop entry at kakoune.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;kakoune.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.oasis.opendocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.oasis.opendocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.openxmlformats-officedocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.openxmlformats-officedocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Printing associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: true
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished printing associations

--- a/src/config/snapshots/handlr__config__main_config__tests__print_handlers_detailed_piped-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__print_handlers_detailed_piped-2.snap
@@ -1,0 +1,47 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/mp4`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/mp4`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/asdf`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/asdf`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding brave.desktop to list of handlers for `video/webm`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `brave.desktop` is invalid: Malformed desktop entry at brave.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/webm`: brave.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `helix.desktop` is invalid: Malformed desktop entry at helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding kakoune.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `kakoune.desktop` is invalid: Malformed desktop entry at kakoune.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;kakoune.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.oasis.opendocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.oasis.opendocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.openxmlformats-officedocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.openxmlformats-officedocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Printing associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: false
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished printing associations

--- a/src/config/snapshots/handlr__config__main_config__tests__print_handlers_json-3.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__print_handlers_json-3.snap
@@ -1,0 +1,90 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/mp4`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/mp4`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/asdf`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/asdf`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding brave.desktop to list of handlers for `video/webm`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `brave.desktop` is invalid: Malformed desktop entry at brave.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/webm`: brave.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `helix.desktop` is invalid: Malformed desktop entry at helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding kakoune.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `kakoune.desktop` is invalid: Malformed desktop entry at kakoune.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;kakoune.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.oasis.opendocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.oasis.opendocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.openxmlformats-officedocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.openxmlformats-officedocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Printing associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: true
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished printing associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/mp4`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/mp4`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/asdf`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/asdf`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding brave.desktop to list of handlers for `video/webm`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `brave.desktop` is invalid: Malformed desktop entry at brave.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/webm`: brave.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `helix.desktop` is invalid: Malformed desktop entry at helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding kakoune.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `kakoune.desktop` is invalid: Malformed desktop entry at kakoune.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;kakoune.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.oasis.opendocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.oasis.opendocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.openxmlformats-officedocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.openxmlformats-officedocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Printing associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: true
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished printing associations

--- a/src/config/snapshots/handlr__config__main_config__tests__print_handlers_json.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__print_handlers_json.snap
@@ -1,5 +1,5 @@
 ---
 source: src/config/main_config.rs
-expression: "String::from_utf8(buffer)?"
+expression: "String::from_utf8(buffer).unwrap()"
 ---
 [{"mime":"application/vnd.oasis.opendocument.*","handlers":["startcenter.desktop"]},{"mime":"application/vnd.openxmlformats-officedocument.*","handlers":["startcenter.desktop"]},{"mime":"text/plain","handlers":["helix.desktop","nvim.desktop","kakoune.desktop"]},{"mime":"video/asdf","handlers":["mpv.desktop"]},{"mime":"video/mp4","handlers":["mpv.desktop"]},{"mime":"video/webm","handlers":["brave.desktop"]}]

--- a/src/config/snapshots/handlr__config__main_config__tests__print_handlers_piped-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__print_handlers_piped-2.snap
@@ -1,0 +1,47 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/mp4`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/mp4`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/asdf`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/asdf`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding brave.desktop to list of handlers for `video/webm`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `brave.desktop` is invalid: Malformed desktop entry at brave.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/webm`: brave.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `helix.desktop` is invalid: Malformed desktop entry at helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding kakoune.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `kakoune.desktop` is invalid: Malformed desktop entry at kakoune.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: helix.desktop;nvim.desktop;kakoune.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.oasis.opendocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.oasis.opendocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding startcenter.desktop to list of handlers for `application/vnd.openxmlformats-officedocument.*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `startcenter.desktop` is invalid: Malformed desktop entry at startcenter.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/vnd.openxmlformats-officedocument.*`: startcenter.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Printing associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: false
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished printing associations

--- a/src/config/snapshots/handlr__config__main_config__tests__properly_assign_files_to_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__properly_assign_files_to_handlers.snap
@@ -1,0 +1,64 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding swayimg.desktop to list of handlers for `image/png`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `swayimg.desktop` is invalid: Malformed desktop entry at swayimg.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `image/png`: swayimg.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mupdf.desktop to list of handlers for `application/pdf`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mupdf.desktop` is invalid: Malformed desktop entry at mupdf.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/pdf`: mupdf.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `a.png`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `a.pdf`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `application/pdf` in mimeapps.list Default Associations: mupdf.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `application/pdf` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `a.pdf`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `application/pdf` in mimeapps.list Default Associations: mupdf.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `application/pdf` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `a.png`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `a.png`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `b.png`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `a.pdf`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `application/pdf` in mimeapps.list Default Associations: mupdf.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `application/pdf` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `a.pdf`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `application/pdf` in mimeapps.list Default Associations: mupdf.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `application/pdf` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `a.png`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `b.png`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations

--- a/src/config/snapshots/handlr__config__main_config__tests__set_and_remove_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__set_and_remove_handlers.snap
@@ -1,0 +1,39 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Setting `Helix.desktop` as handler for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `Helix.desktop` is invalid: Malformed desktop entry at Helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished setting handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Setting `nvim.desktop` as handler for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished setting handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Removing `Helix.desktop` from list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished removing handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Removing `nvim.desktop` from list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: <None>
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished removing handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: ;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 0
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No match for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching entries for `text/plain` in mimeapps.list Added Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::system[0m[2m:[0m No installed handlers found for `text/plain`
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching installed handlers found for `text/plain`

--- a/src/config/snapshots/handlr__config__main_config__tests__set_and_unset_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__set_and_unset_handlers.snap
@@ -1,0 +1,30 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Setting `Helix.desktop` as handler for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `Helix.desktop` is invalid: Malformed desktop entry at Helix.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished setting handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Setting `nvim.desktop` as handler for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: Malformed desktop entry at nvim.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished setting handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Unsetting handler for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: <None>
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished unsetting handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m No handlers configured for `text/plain` in mimeapps.list Default associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No match for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching entries for `text/plain` in mimeapps.list Added Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::system[0m[2m:[0m No installed handlers found for `text/plain`
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching installed handlers found for `text/plain`

--- a/src/config/snapshots/handlr__config__main_config__tests__show_handler-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__show_handler-2.snap
@@ -1,0 +1,19 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding tests/assets/Helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: tests/assets/Helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding tests/assets/org.wezfurlong.wezterm.desktop to list of handlers for `x-scheme-handler/terminal`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `x-scheme-handler/terminal`: tests/assets/org.wezfurlong.wezterm.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Showing handler for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: tests/assets/Helix.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished showing handler

--- a/src/config/snapshots/handlr__config__main_config__tests__show_handler_json-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__show_handler_json-2.snap
@@ -1,0 +1,23 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding tests/assets/Helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: tests/assets/Helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding tests/assets/org.wezfurlong.wezterm.desktop to list of handlers for `x-scheme-handler/terminal`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `x-scheme-handler/terminal`: tests/assets/org.wezfurlong.wezterm.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Showing handler for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: true
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: tests/assets/Helix.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `x-scheme-handler/terminal` in mimeapps.list Default Associations: tests/assets/org.wezfurlong.wezterm.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `x-scheme-handler/terminal` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished showing handler

--- a/src/config/snapshots/handlr__config__main_config__tests__show_handler_json_terminal-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__show_handler_json_terminal-2.snap
@@ -1,0 +1,19 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding tests/assets/Helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: tests/assets/Helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding tests/assets/org.wezfurlong.wezterm.desktop to list of handlers for `x-scheme-handler/terminal`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `x-scheme-handler/terminal`: tests/assets/org.wezfurlong.wezterm.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Showing handler for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: true
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: tests/assets/Helix.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished showing handler

--- a/src/config/snapshots/handlr__config__main_config__tests__show_handler_terminal-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__show_handler_terminal-2.snap
@@ -1,0 +1,19 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding tests/assets/Helix.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: tests/assets/Helix.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding tests/assets/org.wezfurlong.wezterm.desktop to list of handlers for `x-scheme-handler/terminal`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `x-scheme-handler/terminal`: tests/assets/org.wezfurlong.wezterm.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Showing handler for `text/plain`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: tests/assets/Helix.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished showing handler

--- a/src/config/snapshots/handlr__config__main_config__tests__terminal_command_fallback.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__terminal_command_fallback.snap
@@ -1,0 +1,9 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m No handlers configured for `x-scheme-handler/terminal` in mimeapps.list Default associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No match for `x-scheme-handler/terminal` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching entries for `x-scheme-handler/terminal` in mimeapps.list Added Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::system[0m[2m:[0m No installed handlers found for `x-scheme-handler/terminal`
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching installed handlers found for `x-scheme-handler/terminal`

--- a/src/config/snapshots/handlr__config__main_config__tests__terminal_command_set.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__terminal_command_set.snap
@@ -1,0 +1,12 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding tests/assets/org.wezfurlong.wezterm.desktop to list of handlers for `x-scheme-handler/terminal`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `x-scheme-handler/terminal`: tests/assets/org.wezfurlong.wezterm.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `x-scheme-handler/terminal` in mimeapps.list Default Associations: tests/assets/org.wezfurlong.wezterm.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `x-scheme-handler/terminal` in mimeapps.list Default Associations

--- a/src/config/snapshots/handlr__config__main_config__tests__wildcard_mimes.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__wildcard_mimes.snap
@@ -1,0 +1,26 @@
+---
+source: src/config/main_config.rs
+expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
+---
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding mpv.desktop to list of handlers for `video/*`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `mpv.desktop` is invalid: Malformed desktop entry at mpv.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/*`: mpv.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding brave.desktop to list of handlers for `video/webm`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `brave.desktop` is invalid: Malformed desktop entry at brave.desktop
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/webm`: brave.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `video/mp4` in mimeapps.list Default Associations: mpv.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `video/mp4` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `video/asdf` in mimeapps.list Default Associations: mpv.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `video/asdf` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `video/webm` in mimeapps.list Default Associations: brave.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `video/webm` in mimeapps.list Default Associations

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,7 @@ pub enum Error {
 }
 
 impl Error {
+    #[mutants::skip] // Cannot test, relies on user input
     pub fn log(&self) {
         match self {
             Self::Cancelled => info!("{}", self),

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ pub enum Error {
     Xdg(#[from] xdg::BaseDirectoriesError),
     #[error(transparent)]
     Config(#[from] confy::ConfyError),
-    #[error("no handlers found for '{0}'")]
+    #[error("No handlers found for '{0}'")]
     NotFound(String),
     #[error(
         "Could not find a mimetype associated with the file extension: '{0}'"
@@ -15,15 +15,15 @@ pub enum Error {
     AmbiguousExtension(String),
     #[error(transparent)]
     BadMimeType(#[from] mime::FromStrError),
-    #[error("bad mime: {0}")]
+    #[error("Bad mime: {0}")]
     InvalidMime(mime::Mime),
-    #[error("malformed desktop entry at {0}")]
+    #[error("Malformed desktop entry at {0}")]
     BadEntry(std::path::PathBuf),
     #[error(transparent)]
     BadRegex(#[from] regex::Error),
-    #[error("error spawning selector process '{0}'")]
+    #[error("Error spawning selector process '{0}'")]
     Selector(String),
-    #[error("selection cancelled")]
+    #[error("Selection cancelled")]
     Cancelled,
     #[error("Please specify the default terminal with handlr set x-scheme-handler/terminal")]
     NoTerminal,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use tracing::{error, info};
+
 /// Custom error type
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -47,6 +49,15 @@ pub enum Error {
     #[cfg(test)]
     #[error(transparent)]
     FromUtf8(#[from] std::string::FromUtf8Error),
+}
+
+impl Error {
+    pub fn log(&self) {
+        match self {
+            Self::Cancelled => info!("{}", self),
+            _ => error!("{}", self),
+        }
+    }
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,8 @@ pub enum Error {
     BadExec(String, String),
     #[error("Could not split command '{0}' into shell words")]
     BadCmd(String),
+    #[error(transparent)]
+    TracingGlobalDefault(#[from] tracing::dispatcher::SetGlobalDefaultError),
     #[cfg(test)]
     #[error(transparent)]
     BadUrl(#[from] url::ParseError),

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -30,7 +30,7 @@ pub fn init_tracing(cli: &Cli) -> Result<WorkerGuard> {
                     .with_filter(env_filter()),
             )
             // Send all logs to a log file
-            .with(fmt::Layer::new().with_writer(file_writer))
+            .with(fmt::Layer::new().with_writer(file_writer).with_ansi(false))
             // Notify for logs as determined by cli args
             .with(
                 cli.show_notifications()

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -25,7 +25,6 @@ pub fn init_tracing(cli: &Cli) -> Result<WorkerGuard> {
             // Send logs to stdout as determined by cli args
             .with(
                 fmt::Layer::new()
-                    .pretty()
                     .with_writer(std::io::stderr)
                     .with_filter(env_filter()),
             )

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,99 @@
+use std::collections::BTreeMap;
+
+use tracing::{field::Visit, level_filters::LevelFilter};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Layer};
+
+use crate::error::Result;
+
+/// Init global tracing subscriber
+pub fn init_tracing(show_notifications: bool) -> Result<WorkerGuard> {
+    let (file_writer, _guard) =
+        tracing_appender::non_blocking(tracing_appender::rolling::never(
+            xdg::BaseDirectories::new()?.create_cache_directory("handlr")?,
+            "handlr.log",
+        ));
+
+    let env_filter = || {
+        EnvFilter::builder()
+            .with_default_directive(LevelFilter::WARN.into())
+            .from_env_lossy()
+    };
+
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::registry()
+            .with(
+                fmt::Layer::new()
+                    .pretty()
+                    .with_writer(std::io::stderr)
+                    .with_filter(env_filter()),
+            )
+            .with(fmt::Layer::new().with_writer(file_writer))
+            .with(
+                show_notifications
+                    .then_some(NotificationLayer.with_filter(env_filter())),
+            ),
+    )?;
+
+    Ok(_guard)
+}
+
+/// Custom tracing layer for running a notification on relevant events
+struct NotificationLayer;
+
+impl<S> Layer<S> for NotificationLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut fields = BTreeMap::new();
+        let mut visitor = NotificationVisitor(&mut fields);
+        event.record(&mut visitor);
+        let message = fields
+            .get("message")
+            .expect("handlr error: Tracing event did not have any message");
+
+        let (level, icon, urgency, timeout) = match *event.metadata().level() {
+            l if l == tracing::Level::ERROR => {
+                ("error".to_string(), "dialog-error", "critical", 0)
+            }
+            tracing::Level::WARN => {
+                ("warning".to_string(), "dialog-warning", "normal", 10000)
+            }
+            l => (
+                l.as_str().to_lowercase(),
+                "dialog-information",
+                "low",
+                10000,
+            ),
+        };
+
+        std::process::Command::new("notify-send")
+            .arg("--app-name=handlr")
+            .arg(format!("--expire-time={}", timeout))
+            .arg(format!("--icon={}", icon))
+            .arg(format!("handlr {}", level))
+            .arg(format!("--urgency={}", urgency))
+            .arg(message)
+            .spawn()
+            .and_then(|mut c| c.wait())
+            .expect("handlr error: Could not run `notify-send`");
+    }
+}
+
+struct NotificationVisitor<'a>(&'a mut BTreeMap<String, String>);
+
+impl Visit for NotificationVisitor<'_> {
+    fn record_debug(
+        &mut self,
+        field: &tracing::field::Field,
+        value: &dyn std::fmt::Debug,
+    ) {
+        self.0
+            .insert(field.name().to_string(), format!("{:?}", value));
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -53,6 +53,7 @@ impl<S> Layer<S> for NotificationLayer
 where
     S: tracing::Subscriber,
 {
+    #[mutants::skip] // Cannot test, relies on dbus
     fn on_event(
         &self,
         event: &tracing::Event,
@@ -96,6 +97,7 @@ where
 struct NotificationVisitor<'a>(&'a mut String);
 
 impl Visit for NotificationVisitor<'_> {
+    #[mutants::skip] // Cannot test independently of NotificationLayer
     fn record_debug(
         &mut self,
         field: &tracing::field::Field,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,11 +15,8 @@ use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::{
-    fmt::{self},
-    layer::SubscriberExt,
-    EnvFilter, Layer,
-};
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Layer};
+use tracing_unwrap::ResultExt;
 
 #[mutants::skip] // Cannot test directly at the moment
 fn main() {
@@ -31,7 +28,7 @@ fn main() {
     let cli = Cli::parse();
 
     let _guard = init_tracing()
-        .expect("handlr: could not initialize global tracing subscriber");
+        .expect("handlr error: Could not initialize global tracing subscriber");
 
     let terminal_output = cli
         .terminal_output
@@ -49,7 +46,7 @@ fn main() {
                 ])
                 .spawn()
                 .and_then(|mut c| c.wait())
-                .expect("handlr: could not run `notify-send`");
+                .expect_or_log("Could not run `notify-send`");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,6 @@ mod config;
 mod error;
 mod logging;
 
-use std::io::IsTerminal;
-
 use cli::{Cli, Cmd};
 use common::mime_table;
 use config::Config;
@@ -25,22 +23,18 @@ fn main() {
 
     let cli = Cli::parse();
 
-    let terminal_output = cli
-        .terminal_output
-        .unwrap_or(std::io::stdout().is_terminal());
-
-    let _guard = init_tracing(!terminal_output && cli.enable_notifications)
+    let _guard = init_tracing(cli.show_notifications())
         .expect("handlr error: Could not initialize global tracing subscriber");
 
-    if let Err(e) = run(cli, terminal_output) {
+    if let Err(e) = run(cli) {
         tracing::error!("{}", e)
     }
 }
 
 /// Run main program logic
 #[mutants::skip] // Cannot test directly at the moment
-fn run(cli: Cli, terminal_output: bool) -> Result<()> {
-    let mut config = Config::new(terminal_output)?;
+fn run(cli: Cli) -> Result<()> {
+    let mut config = Config::new(cli.terminal_output())?;
 
     let mut stdout = std::io::stdout().lock();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
 
     let cli = Cli::parse();
 
-    let _guard = init_tracing(cli.show_notifications())
+    let _guard = init_tracing(&cli)
         .expect("handlr error: Could not initialize global tracing subscriber");
 
     if let Err(e) = run(cli) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod common;
 mod config;
 mod error;
 mod logging;
+mod testing;
 
 use cli::{Cli, Cmd};
 use common::mime_table;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,8 @@ fn main() {
     let _guard = init_tracing(&cli)
         .expect("handlr error: Could not initialize global tracing subscriber");
 
-    if let Err(e) = run(cli) {
-        tracing::error!("{}", e)
+    if let Err(error) = run(cli) {
+        error.log()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use logging::init_tracing;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
+use tracing::debug;
 
 #[mutants::skip] // Cannot test directly at the moment
 fn main() {
@@ -37,6 +38,8 @@ fn run(cli: Cli) -> Result<()> {
     let mut config = Config::new(cli.terminal_output())?;
 
     let mut stdout = std::io::stdout().lock();
+
+    debug!("Interactive terminal detected: {}", config.terminal_output);
 
     match cli.command {
         Cmd::Set { mime, handler } => config.set_handler(&mime, &handler),

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,12 @@
+//! Testing helpers
+#![cfg(test)]
+
+use std::{
+    io::{self, Write},
+    sync::{Mutex, MutexGuard},
+};
+
+/// Helper function for insta settings
+pub fn timestamp_filter() -> Vec<(&'static str, &'static str)> {
+    vec![(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d*\.\d*Z", "[TIMESTAMP]")]
+}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,12 +1,53 @@
 //! Testing helpers
 #![cfg(test)]
 
-use std::{
-    io::{self, Write},
-    sync::{Mutex, MutexGuard},
-};
-
 /// Helper function for insta settings
 pub fn timestamp_filter() -> Vec<(&'static str, &'static str)> {
     vec![(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d*\.\d*Z", "[TIMESTAMP]")]
+}
+
+/// Helper macro to snapshot test logs
+#[macro_export]
+macro_rules! logs_snapshot_test {
+    ($name:ident, $block:block) => {
+        #[test]
+        fn $name() -> $crate::error::Result<()> {
+            use tracing::{subscriber, Level};
+            use tracing_subscriber::{
+                filter, fmt, layer::SubscriberExt, registry,
+            };
+
+            let (mut pipe_read, pipe_write) = pipe::pipe();
+
+            // Create scope so guards are dropped before assertion and logs are flushed
+            // Otherwise, the tests using this macro will freeze
+            {
+                let (writer, _writer_guard) =
+                    tracing_appender::non_blocking(pipe_write);
+                let _default_guard = subscriber::set_default(
+                    registry()
+                        .with(fmt::Layer::new().with_writer(writer))
+                        // Filter out all logs from other crates so the user is not overwhelmed looking at the logs
+                        .with(
+                            filter::Targets::new()
+                                .with_target("handlr", Level::TRACE)
+                                .with_target("tracing_unwrap", Level::WARN),
+                        ),
+                );
+                $block
+            }
+
+            let mut buffer = Vec::<u8>::new();
+            pipe_read.read_to_end(&mut buffer)?;
+
+            insta::with_settings!(
+                {
+                    filters => testing::timestamp_filter()
+                },
+                { insta::assert_snapshot!(String::from_utf8(buffer).expect("Buffer is invalid utf8")) }
+            );
+
+            Ok(())
+        }
+    };
 }

--- a/tests/snapshots/terminal_override__terminal_output_tests_force_false.snap
+++ b/tests/snapshots/terminal_override__terminal_output_tests_force_false.snap
@@ -4,6 +4,8 @@ info:
   program: handlr
   args:
     - "--force-terminal-output=false"
+    - "-vvv"
+    - "--disable-notifications"
     - mime
     - "./assets"
 ---
@@ -14,3 +16,7 @@ path    	mime
 ./assets	application/x-zerosize
 
 ----- stderr -----
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr[0m[2m:[0m Interactive terminal detected: false
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::common::path[0m[2m:[0m Printing mime information for paths: ["./assets"]
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::common::path[0m[2m:[0m JSON output: false
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::common::path[0m[2m:[0m Finished printing mime information

--- a/tests/snapshots/terminal_override__terminal_output_tests_force_true.snap
+++ b/tests/snapshots/terminal_override__terminal_output_tests_force_true.snap
@@ -4,6 +4,8 @@ info:
   program: handlr
   args:
     - "--force-terminal-output=true"
+    - "-vvv"
+    - "--disable-notifications"
     - mime
     - "./assets"
 ---
@@ -17,3 +19,7 @@ exit_code: 0
 └──────────┴────────────────────────┘
 
 ----- stderr -----
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr[0m[2m:[0m Interactive terminal detected: true
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::common::path[0m[2m:[0m Printing mime information for paths: ["./assets"]
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::common::path[0m[2m:[0m JSON output: false
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::common::path[0m[2m:[0m Finished printing mime information

--- a/tests/terminal_override.rs
+++ b/tests/terminal_override.rs
@@ -1,3 +1,6 @@
+#[path = "../src/testing.rs"]
+mod testing;
+
 use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 use std::process::Command;
 
@@ -12,16 +15,11 @@ fn test_terminal_output(terminal_output: bool) -> Command {
     cmd
 }
 
-/// Helper function for insta settings
-fn timestamp_filter() -> Vec<(&'static str, &'static str)> {
-    vec![(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d*\.\d*Z", "[TIMESTAMP]")]
-}
-
 #[test]
 fn terminal_output_tests_force_true() {
     insta::with_settings!(
         {
-            filters => timestamp_filter()
+            filters => testing::timestamp_filter()
         },
         { assert_cmd_snapshot!(test_terminal_output(true)) }
     )
@@ -31,7 +29,7 @@ fn terminal_output_tests_force_true() {
 fn terminal_output_tests_force_false() {
     insta::with_settings!(
         {
-            filters => timestamp_filter()
+            filters => testing::timestamp_filter()
         },
         { assert_cmd_snapshot!(test_terminal_output(false)) }
     )

--- a/tests/terminal_override.rs
+++ b/tests/terminal_override.rs
@@ -5,17 +5,34 @@ use std::process::Command;
 fn test_terminal_output(terminal_output: bool) -> Command {
     let mut cmd = Command::new(get_cargo_bin("handlr"));
     cmd.arg(format!("--force-terminal-output={}", terminal_output))
+        .arg("-vvv") // Maximum verbosity
+        .arg("--disable-notifications") // Not much point showing these in tests
         .arg("mime")
         .arg("./assets");
     cmd
 }
 
+/// Helper function for insta settings
+fn timestamp_filter() -> Vec<(&'static str, &'static str)> {
+    vec![(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d*\.\d*Z", "[TIMESTAMP]")]
+}
+
 #[test]
 fn terminal_output_tests_force_true() {
-    assert_cmd_snapshot!(test_terminal_output(true))
+    insta::with_settings!(
+        {
+            filters => timestamp_filter()
+        },
+        { assert_cmd_snapshot!(test_terminal_output(true)) }
+    )
 }
 
 #[test]
 fn terminal_output_tests_force_false() {
-    assert_cmd_snapshot!(test_terminal_output(false))
+    insta::with_settings!(
+        {
+            filters => timestamp_filter()
+        },
+        { assert_cmd_snapshot!(test_terminal_output(false)) }
+    )
 }


### PR DESCRIPTION
Adds support for logging and a flag to adjust the verbosity of the logs, which closes #105.

Further details are in `README.md`

One of the logged messages is a warning if a handler set through `handlr set` or `handlr add`, which closes #93.

Unfortunately, I had to remove the `enable-notifications` config file option since I had trouble getting things to work otherwise, although there has not yet been a release since I added it anyways. The equivalent cli flag still remains.