### PR TITLE
feat!: combine `--enable-selector` and `--disable-selector` 

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -267,13 +267,9 @@ pub struct SelectorArgs {
     /// Override the configured selector command
     #[clap(long, short)]
     pub selector: Option<String>,
-    /// Enable selector, overrides `enable_selector`
+    /// Override whether or not the selector is enabled
     #[clap(long, short)]
-    pub enable_selector: bool,
-    /// Disable selector, overrides `enable_selector`
-    #[clap(long, short)]
-    #[clap(overrides_with = "enable_selector")]
-    pub disable_selector: bool,
+    pub enable_selector: Option<bool>,
 }
 
 /// Generate candidates for mimes and file extensions to use

--- a/src/config/config_file.rs
+++ b/src/config/config_file.rs
@@ -58,9 +58,9 @@ impl ConfigFile {
             self.selector = selector;
         }
 
-        self.enable_selector = (self.enable_selector
-            || selector_args.enable_selector)
-            && !selector_args.disable_selector;
+        self.enable_selector = selector_args
+            .enable_selector
+            .unwrap_or(self.enable_selector);
 
         debug!("Selector enabled: {}", self.enable_selector);
     }

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -818,8 +818,7 @@ mod tests {
 
         config.override_selector(SelectorArgs {
             selector: Some("fzf".to_string()),
-            enable_selector: true,
-            disable_selector: false,
+            enable_selector: Some(true),
         });
 
         assert_eq!(config.config.selector, "fzf");
@@ -827,8 +826,7 @@ mod tests {
 
         config.override_selector(SelectorArgs {
             selector: Some("fuzzel --dmenu --prompt='Open With: '".to_string()),
-            enable_selector: false,
-            disable_selector: true,
+            enable_selector: Some(false),
         });
 
         assert_eq!(
@@ -839,8 +837,6 @@ mod tests {
     });
 
     crate::logs_snapshot_test!(dont_override_selector, {
-        // NOTE: `enable_selector` and `disable_selector` should not both be true in practice anyways
-
         let mut config = Config::default();
 
         // Ensure defaults are as expected just in case
@@ -849,8 +845,7 @@ mod tests {
 
         config.override_selector(SelectorArgs {
             selector: None,
-            enable_selector: false,
-            disable_selector: false,
+            enable_selector: None,
         });
 
         assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");
@@ -858,8 +853,7 @@ mod tests {
 
         config.override_selector(SelectorArgs {
             selector: None,
-            enable_selector: false,
-            disable_selector: true,
+            enable_selector: Some(false),
         });
 
         assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");
@@ -870,8 +864,7 @@ mod tests {
 
         config.override_selector(SelectorArgs {
             selector: None,
-            enable_selector: true,
-            disable_selector: false,
+            enable_selector: Some(true),
         });
 
         assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");
@@ -879,8 +872,7 @@ mod tests {
 
         config.override_selector(SelectorArgs {
             selector: None,
-            enable_selector: false,
-            disable_selector: false,
+            enable_selector: None,
         });
 
         assert_eq!(config.config.selector, "rofi -dmenu -i -p 'Open With: '");


### PR DESCRIPTION
Combines `--enable-selector` and `--disable-selector` into a single `--enable-selector` for consistency with the `--terminal-output` option. No other behavior changes.