### PR TITLE
Enabled selector for fallback options

### DIFF
--- a/src/apps/system.rs
+++ b/src/apps/system.rs
@@ -33,13 +33,6 @@ impl SystemApps {
         Some(associations?.clone())
     }
 
-    /// Get the primary of handler associated with a given mime
-    pub fn get_handler(&self, mime: &Mime) -> Option<DesktopHandler> {
-        let handler = self.get_handlers(mime)?.front()?.clone();
-        debug!("Installed handler chosen for `{}`: {}", mime, handler);
-        Some(handler)
-    }
-
     /// Get all system-level desktop entries on the system
     #[mutants::skip] // Cannot test directly, depends on system state
     pub fn get_entries(
@@ -131,13 +124,6 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(
-            system_apps
-                .get_handler(&mime::TEXT_PLAIN)
-                .expect("Could not get handler")
-                .to_string(),
-            "helix.desktop"
-        );
         assert_eq!(
             system_apps
                 .get_handlers(&mime::TEXT_PLAIN)

--- a/src/apps/user.rs
+++ b/src/apps/user.rs
@@ -1,6 +1,5 @@
 use crate::{
-    common::{DesktopHandler, Handleable, MIME_TYPES},
-    config::{ConfigFile, Languages},
+    common::{DesktopHandler, MIME_TYPES},
     error::{Error, Result},
 };
 use derive_more::{Deref, DerefMut};
@@ -243,15 +242,7 @@ impl MimeApps {
     }
 
     /// Get the handler associated with a given mime from mimeapps.list's default apps
-    #[mutants::skip] // Cannot entirely test, namely cannot test selector or filtering and associated logging
-    pub fn get_handler_from_user(
-        &self,
-        mime: &Mime,
-        config_file: &ConfigFile,
-        languages: &Languages,
-    ) -> Result<DesktopHandler> {
-        let error = Error::NotFound(mime.to_string());
-        // Check for an exact match first and then fall back to wildcard
+    pub fn get_default_handlers(&self, mime: &Mime) -> Result<&DesktopList> {
         match self
             .default_apps
             .get(mime)
@@ -262,60 +253,11 @@ impl MimeApps {
                     "Configured handlers for `{}` in mimeapps.list Default Associations: {}",
                     mime, handlers
                 );
-                // Prepares for selector and filters out apps that do not exist
-                let handlers = handlers
-                    .iter()
-                    .flat_map(|h| -> Result<(&DesktopHandler, String)> {
-                        // Filtering breaks testing, so treat every app as valid
-
-                        if cfg!(test) {
-                            Ok((h, h.to_string()))
-                        } else {
-                            let entry = h.get_entry(languages);
-                            if let Err(ref e) = entry {
-                                debug!(
-                                    "Desktop entry `{}` is invalid: {}",
-                                    h, e
-                                );
-                            } else {
-                                debug!("Desktop entry `{}` is valid", h);
-                            }
-
-                            Ok((h, entry?.name))
-                        }
-                    })
-                    .collect_vec();
-
-                debug!(
-                    "Selector enabled: {}, number of set handlers: {}",
-                    config_file.enable_selector,
-                    handlers.len()
-                );
-                if config_file.enable_selector && handlers.len() > 1 {
-                    info!("Running selector: {}", &config_file.selector);
-                    let handler = {
-                        let name = select(
-                            &config_file.selector,
-                            handlers.iter().map(|h| h.1.clone()),
-                        )?;
-
-                        handlers
-                            .into_iter()
-                            .find(|h| h.1 == name)
-                            .ok_or(error)?
-                            .0
-                            .clone()
-                    };
-
-                    Ok(handler)
-                } else {
-                    info!("Not running selector, choosing first handler");
-                    Ok(handlers.first().ok_or(error)?.0.clone())
-                }
+                Ok(handlers)
             }
             None => {
                 info!("No handlers configured for `{}` in mimeapps.list Default associations", mime);
-                Err(error)
+                Err(Error::NotFound(mime.to_string()))
             }
         }
     }
@@ -387,44 +329,6 @@ impl MimeApps {
         self.serialize(&mut ser)?;
 
         Ok(())
-    }
-}
-
-/// Run given selector command
-#[mutants::skip] // Cannot test directly, runs external command
-fn select<O: Iterator<Item = String>>(
-    selector: &str,
-    mut opts: O,
-) -> Result<String> {
-    use std::{io::prelude::*, process::Stdio};
-
-    let process = {
-        execute::command(selector)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()?
-    };
-
-    let output = {
-        process
-            .stdin
-            .ok_or_else(|| Error::Selector(selector.to_string()))?
-            .write_all(opts.join("\n").as_bytes())?;
-
-        let mut output = String::with_capacity(24);
-
-        process
-            .stdout
-            .ok_or_else(|| Error::Selector(selector.to_string()))?
-            .read_to_string(&mut output)?;
-
-        output.trim_end().to_owned()
-    };
-
-    if output.is_empty() {
-        Err(Error::Cancelled)
-    } else {
-        Ok(output)
     }
 }
 
@@ -503,17 +407,12 @@ mod tests {
     fn mimeapps_empty_entry_fallback() -> Result<()> {
         let file = File::open("./tests/assets/mimeapps_empty_entry.list")?;
         let mime_apps = MimeApps::read_from(file)?;
-        let config_file = ConfigFile::default();
 
         assert_eq!(
             mime_apps
-                .get_handler_from_user(
-                    &mime::TEXT_PLAIN,
-                    &config_file,
-                    &Vec::new()
-                )?
+                .get_default_handlers(&mime::TEXT_PLAIN)?
                 .to_string(),
-            "nvim.desktop"
+            "nvim.desktop;Helix.desktop;"
         );
 
         Ok(())

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -79,44 +79,111 @@ impl Config {
         })
     }
 
-    /// Get the handler associated with a given mime
-    #[mutants::skip] // Cannot test match guard because it relies on user interactivity
-    pub fn get_handler(&self, mime: &Mime) -> Result<DesktopHandler> {
-        match self.mime_apps.get_handler_from_user(mime, &self.config, &self.languages) {
-            Err(e) if matches!(e, Error::Cancelled) => Err(e),
-            h => h
-                .inspect(|_| {
-                    info!("Match found for `{}` in mimeapps.list Default Associations", mime);
-                })
-                .or_else(|_|{
-                    info!("No match for `{}` in mimeapps.list Default Associations", mime);
-                    self.get_handler_from_added_associations(mime)}),
+    /// Choose an appropriate handler from a given list, possibly with an interactive selector.
+    #[mutants::skip] // Cannot entirely test, namely cannot test selector or filtering and associated logging
+    pub fn select_handler(
+        &self,
+        mime: &Mime,
+        handlers: &DesktopList,
+    ) -> Result<DesktopHandler> {
+        let error = Error::NotFound(mime.to_string());
+        let config_file = &self.config;
+        let languages = &self.languages;
+        // Prepares for selector and filters out apps that do not exist
+        let handlers = handlers
+            .iter()
+            .flat_map(|h| -> Result<(&DesktopHandler, String)> {
+                // Filtering breaks testing, so treat every app as valid
+
+                if cfg!(test) {
+                    Ok((h, h.to_string()))
+                } else {
+                    let entry = h.get_entry(languages);
+                    if let Err(ref e) = entry {
+                        debug!("Desktop entry `{}` is invalid: {}", h, e);
+                    } else {
+                        debug!("Desktop entry `{}` is valid", h);
+                    }
+
+                    Ok((h, entry?.name))
+                }
+            })
+            .collect_vec();
+
+        debug!(
+            "Selector enabled: {}, number of set handlers: {}",
+            config_file.enable_selector,
+            handlers.len()
+        );
+        if config_file.enable_selector && handlers.len() > 1 {
+            info!("Running selector: {}", &config_file.selector);
+            let handler = {
+                let name = select(
+                    &config_file.selector,
+                    handlers.iter().map(|h| h.1.clone()),
+                )?;
+
+                handlers
+                    .into_iter()
+                    .find(|h| h.1 == name)
+                    .ok_or(error)?
+                    .0
+                    .clone()
+            };
+
+            Ok(handler)
+        } else {
+            info!("Not running selector, choosing first handler");
+            Ok(handlers.first().ok_or(error)?.0.clone())
         }
     }
 
-    /// Get the handler associated with a given mime from mimeapps.list's added associations
-    /// If there is none, default to the system apps
-    fn get_handler_from_added_associations(
-        &self,
-        mime: &Mime,
-    ) -> Result<DesktopHandler> {
-        self.mime_apps
-            .added_associations
-            .get(mime)
-            .inspect(|_|
-                info!("Found matching entry for `{}` in mimeapps.list Added Associations", mime)
-            )
-            .map_or_else(
-                || {
-                    info!("No matching entries for `{}` in mimeapps.list Added Associations", mime);
-                    self.system_apps.get_handler(mime)
-                },
-                |h| h.front().cloned(),
-            )
-            .ok_or_else(|| {
-                info!("No matching installed handlers found for `{}`", mime);
-                Error::NotFound(mime.to_string())
-            })
+    /// Get the handler associated with a given mime
+    #[mutants::skip] // Cannot test because it relies on user interactivity
+    pub fn get_handler(&self, mime: &Mime) -> Result<DesktopHandler> {
+        // Check in Default associations
+        if let Ok(handlers) = self.mime_apps.get_default_handlers(mime) {
+            info!(
+                "Match found for `{}` in mimeapps.list Default Associations",
+                mime
+            );
+            match self.select_handler(mime, handlers) {
+                Err(e) if matches!(e, Error::Cancelled) => return Err(e),
+                Ok(h) => return Ok(h),
+                _ => (),
+            }
+        }
+        info!(
+            "No match for `{}` in mimeapps.list Default Associations",
+            mime
+        );
+
+        // Check in Added associations
+        if let Some(handlers) = self.mime_apps.added_associations.get(mime) {
+            info!("Found matching entry for `{}` in mimeapps.list Added Associations", mime);
+            match self.select_handler(mime, handlers) {
+                Err(e) if matches!(e, Error::Cancelled) => return Err(e),
+                Ok(h) => return Ok(h),
+                _ => (),
+            }
+        }
+        info!(
+            "No matching entries for `{}` in mimeapps.list Added Associations",
+            mime
+        );
+
+        // Check in System applications
+        if let Some(handlers) = self.system_apps.get_handlers(mime) {
+            info!("Found matching entry for `{}` in System applications", mime);
+            match self.select_handler(mime, &handlers) {
+                Err(e) if matches!(e, Error::Cancelled) => return Err(e),
+                Ok(h) => return Ok(h),
+                _ => (),
+            }
+        }
+
+        info!("No matching installed handlers found for `{}`", mime);
+        Err(Error::NotFound(mime.to_string()))
     }
 
     /// Given a mime and arguments, launch the associated handler with the arguments
@@ -388,6 +455,45 @@ impl Config {
         self.config.override_selector(selector_args);
     }
 }
+
+/// Run given selector command
+#[mutants::skip] // Cannot test directly, runs external command
+fn select<O: Iterator<Item = String>>(
+    selector: &str,
+    mut opts: O,
+) -> Result<String> {
+    use std::{io::prelude::*, process::Stdio};
+
+    let process = {
+        execute::command(selector)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?
+    };
+
+    let output = {
+        process
+            .stdin
+            .ok_or_else(|| Error::Selector(selector.to_string()))?
+            .write_all(opts.join("\n").as_bytes())?;
+
+        let mut output = String::with_capacity(24);
+
+        process
+            .stdout
+            .ok_or_else(|| Error::Selector(selector.to_string()))?
+            .read_to_string(&mut output)?;
+
+        output.trim_end().to_owned()
+    };
+
+    if output.is_empty() {
+        Err(Error::Cancelled)
+    } else {
+        Ok(output)
+    }
+}
+
 
 /// Internal helper struct for turning MimeApps into tabular data
 #[derive(PartialEq, Eq, PartialOrd, Ord, Tabled, Serialize)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,4 @@
 mod config_file;
 mod main_config;
 
-pub use config_file::ConfigFile;
 pub use main_config::{get_languages, Config, Languages};

--- a/src/config/snapshots/handlr__config__main_config__tests__add_and_remove_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__add_and_remove_handlers.snap
@@ -8,31 +8,32 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
 [2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: No such file or directory (os error 2)
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;nvim.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;nvim.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 2
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 2
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Removing `Helix.desktop` from list of handlers for `text/plain`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: nvim.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished removing handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Removing `nvim.desktop` from list of handlers for `text/plain`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: <None>
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished removing handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: ;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 0
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 0
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No match for `text/plain` in mimeapps.list Default Associations
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching entries for `text/plain` in mimeapps.list Added Associations
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::system[0m[2m:[0m No installed handlers found for `text/plain`

--- a/src/config/snapshots/handlr__config__main_config__tests__add_and_unset_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__add_and_unset_handlers.snap
@@ -8,18 +8,18 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
 [2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: No such file or directory (os error 2)
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;nvim.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;nvim.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 2
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 2
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Unsetting handler for `text/plain`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: <None>
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished unsetting handler

--- a/src/config/snapshots/handlr__config__main_config__tests__properly_assign_files_to_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__properly_assign_files_to_handlers.snap
@@ -14,51 +14,51 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/a.png`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/a.pdf`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `application/pdf` in mimeapps.list Default Associations: mupdf.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `application/pdf` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/a.pdf`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `application/pdf` in mimeapps.list Default Associations: mupdf.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `application/pdf` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/a.png`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/a.png`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/b.png`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/a.pdf`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `application/pdf` in mimeapps.list Default Associations: mupdf.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `application/pdf` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/a.pdf`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `application/pdf` in mimeapps.list Default Associations: mupdf.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `application/pdf` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/a.png`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/b.png`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler

--- a/src/config/snapshots/handlr__config__main_config__tests__set_and_remove_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__set_and_remove_handlers.snap
@@ -8,31 +8,32 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished setting handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Setting `nvim.desktop` as handler for `text/plain`
 [2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: No such file or directory (os error 2)
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: nvim.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished setting handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Removing `Helix.desktop` from list of handlers for `text/plain`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: nvim.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished removing handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Removing `nvim.desktop` from list of handlers for `text/plain`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: <None>
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished removing handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: ;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 0
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 0
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No match for `text/plain` in mimeapps.list Default Associations
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching entries for `text/plain` in mimeapps.list Added Associations
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::system[0m[2m:[0m No installed handlers found for `text/plain`

--- a/src/config/snapshots/handlr__config__main_config__tests__set_and_unset_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__set_and_unset_handlers.snap
@@ -8,18 +8,18 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: Helix.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished setting handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: Helix.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Setting `nvim.desktop` as handler for `text/plain`
 [2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: No such file or directory (os error 2)
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: nvim.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished setting handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Unsetting handler for `text/plain`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: <None>
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished unsetting handler

--- a/src/config/snapshots/handlr__config__main_config__tests__show_handler-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__show_handler-2.snap
@@ -13,7 +13,7 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Showing handler for `text/plain`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: false
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: tests/assets/Helix.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished showing handler

--- a/src/config/snapshots/handlr__config__main_config__tests__show_handler_json-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__show_handler_json-2.snap
@@ -13,11 +13,11 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Showing handler for `text/plain`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: true
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: tests/assets/Helix.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `x-scheme-handler/terminal` in mimeapps.list Default Associations: tests/assets/org.wezfurlong.wezterm.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `x-scheme-handler/terminal` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished showing handler

--- a/src/config/snapshots/handlr__config__main_config__tests__show_handler_json_terminal-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__show_handler_json_terminal-2.snap
@@ -13,7 +13,7 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Showing handler for `text/plain`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: true
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: tests/assets/Helix.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished showing handler

--- a/src/config/snapshots/handlr__config__main_config__tests__show_handler_terminal-2.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__show_handler_terminal-2.snap
@@ -13,7 +13,7 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Showing handler for `text/plain`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m JSON output: false
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: tests/assets/Helix.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished showing handler

--- a/src/config/snapshots/handlr__config__main_config__tests__terminal_command_set.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__terminal_command_set.snap
@@ -7,6 +7,6 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `x-scheme-handler/terminal`: tests/assets/org.wezfurlong.wezterm.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `x-scheme-handler/terminal` in mimeapps.list Default Associations: tests/assets/org.wezfurlong.wezterm.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `x-scheme-handler/terminal` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler

--- a/src/config/snapshots/handlr__config__main_config__tests__wildcard_mimes.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__wildcard_mimes.snap
@@ -13,14 +13,14 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `video/webm`: brave.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `video/mp4` in mimeapps.list Default Associations: mpv.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `video/mp4` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `video/asdf` in mimeapps.list Default Associations: mpv.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `video/asdf` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `video/webm` in mimeapps.list Default Associations: brave.desktop;
-[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
-[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `video/webm` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::config::main_config[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Not running selector, choosing first handler


### PR DESCRIPTION
Currently handlr only opens the selector when multiple applications are defined as the default for a mimetype. This means if no default application was defined but multiple compatible applications are installed, handlr will just open one at random, instead of allowing the user to chose their preferred application. This patch solves this, by using the selector for the fallback options of the "Added Associations" and System applications too.
The new code consists of two main functions: `select_handler` contains the code for filtering the valid handlers and opening the selector that was previously in `get_handler_from_user`. (`get_handler_from_user` now just simply returns the user defined default handlers.) `get_handler` has been rewritten and combined with `get_handler_from_added_associations`, using the new `select_handler` function if appropriate.

One minor problem with my implementation is that the `select_handler` function requires the `select` function from the `user` module, but is currently implemented on the `Config` struct in `main_config.rs`. (It doesn't really make sense to implement it on the `MimeApps` struct like `get_handler_from_user`, since it is functionally independent from it.) Thus I had to decalre the `user` module public. It might be worth to move the `select` function to `main_config.rs` too or otherwise refactor the code.
As I have implemented it, the `select_handler` function also handles the filtering out of invalid handlers. It might be worth to extract this code into it's own function that is then called from `get_handler` before the various `if let` statements.

I should further note that because this PR changes the code for the `get_handler_from_user` and the `get_handler` function quite significantly, many of the regression tests currently fail. I also haven't updated the tests as of yet, but that should not be a problem once this PR is ready for merge.