### PR TITLE
Check parent mimetypes if no handler was found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3106,8 +3106,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 [[package]]
 name = "xdg-mime"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d325d0ca93fb1984a56eb926f019acfc67bd2ec559b0dbf09cafcc92e81ec9"
+source = "git+https://github.com/ebassi/xdg-mime-rs.git#f8efb3fb1fad582539e2af7d1e9fbc9613dcc7d9"
 dependencies = [
  "dirs-next",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ mime = "0.3.16"
 mime-db = "1.3.0"
 confy = "0.4.0"
 serde = { version = "1.0.125", features = ["derive"] }
-xdg-mime = "0.4.0"
+xdg-mime = { version = "0.4.0", git = "https://github.com/ebassi/xdg-mime-rs.git" }
 tabled = "0.15.0"
 serde_json = "1.0"
 enum_dispatch = "0.3.13"

--- a/src/config/main_config.rs
+++ b/src/config/main_config.rs
@@ -248,13 +248,30 @@ impl Config {
 
     /// Get the handler associated with a given path
     fn get_handler_from_path(&self, path: &UserPath) -> Result<Handler> {
-        Ok(if let Ok(handler) = self.config.get_regex_handler(path) {
+        if let Ok(handler) = self.config.get_regex_handler(path) {
             info!("Using regex handler for `{}`", path);
-            handler.into()
+            return Ok(handler.into());
         } else {
             info!("No matching regex handlers found for `{}`", path);
-            self.get_handler(&path.get_mime()?)?.into()
-        })
+            let initial_mime = path.get_mime()?;
+            let initial_mime_name = initial_mime.to_string();
+            let mut all_mime = VecDeque::new();
+            all_mime.push_back(initial_mime);
+            let mimedb = xdg_mime::SharedMimeInfo::new();
+            while let Some(mime) = all_mime.pop_front() {
+                match self.get_handler(&mime) {
+                    Ok(h) => return Ok(h.into()),
+                    Err(Error::NotFound(_)) => {
+                        if let Some(parents) = mimedb.get_parents_aliased(&mime) {
+                            info!("Found parents for mime {}: {:?}", mime, parents);
+                            all_mime.append(&mut parents.into());
+                        }
+                    },
+                    Err(e) => return Err(e),
+                }
+            }
+            return Err(Error::NotFound(initial_mime_name));
+        }
     }
 
     /// Get the command for the x-scheme-handler/terminal handler if one is set.
@@ -918,6 +935,10 @@ mod tests {
             &Mime::from_str("application/pdf")?,
             &DesktopHandler::assume_valid("mupdf.desktop".into()),
         )?;
+        config.add_handler(
+            &Mime::from_str("text/plain")?,
+            &DesktopHandler::assume_valid("nvim.desktop".into()),
+        )?;
 
         let mut expected_handlers = HashMap::new();
         expected_handlers.insert(
@@ -972,6 +993,46 @@ mod tests {
                 UserPath::from_str("tests/assets/a.pdf")?,
                 UserPath::from_str("tests/assets/a.png")?,
                 UserPath::from_str("tests/assets/b.png")?
+            ])?,
+            expected_handlers
+        );
+
+        let mut expected_handlers = HashMap::new();
+        expected_handlers.insert(
+            Handler::new("nvim.desktop"),
+            vec![
+                "tests/assets/empty.md".to_owned(),
+                "tests/assets/empty.txt".to_owned(),
+            ],
+        );
+
+        assert_eq!(
+            config.assign_files_to_handlers(&[
+                UserPath::from_str("tests/assets/empty.md")?,
+                UserPath::from_str("tests/assets/empty.txt")?
+            ])?,
+            expected_handlers
+        );
+
+        config.add_handler(
+            &Mime::from_str("text/markdown")?,
+            &DesktopHandler::assume_valid("emacs.desktop".into()),
+        )?;
+
+        let mut expected_handlers = HashMap::new();
+        expected_handlers.insert(
+            Handler::new("nvim.desktop"),
+            vec!["tests/assets/empty.txt".to_owned()],
+        );
+        expected_handlers.insert(
+            Handler::new("emacs.desktop"),
+            vec!["tests/assets/empty.md".to_owned()],
+        );
+
+        assert_eq!(
+            config.assign_files_to_handlers(&[
+                UserPath::from_str("tests/assets/empty.md")?,
+                UserPath::from_str("tests/assets/empty.txt")?
             ])?,
             expected_handlers
         );

--- a/src/config/snapshots/handlr__config__main_config__tests__properly_assign_files_to_handlers.snap
+++ b/src/config/snapshots/handlr__config__main_config__tests__properly_assign_files_to_handlers.snap
@@ -12,6 +12,11 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `application/pdf`: mupdf.desktop;
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding nvim.desktop to list of handlers for `text/plain`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `nvim.desktop` is invalid: No such file or directory (os error 2)
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/plain`: nvim.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/a.png`
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `image/png` in mimeapps.list Default Associations: swayimg.desktop;
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
@@ -62,3 +67,34 @@ expression: "String :: from_utf8(buffer).expect(\"Buffer is invalid utf8\")"
 [2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
 [2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `image/png` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/empty.md`
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m No handlers configured for `text/markdown` in mimeapps.list Default associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No match for `text/markdown` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching entries for `text/markdown` in mimeapps.list Added Associations
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::system[0m[2m:[0m No installed handlers found for `text/markdown`
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching installed handlers found for `text/markdown`
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Found parents for mime text/markdown: ["text/plain"]
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/empty.txt`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Adding emacs.desktop to list of handlers for `text/markdown`
+[2m[TIMESTAMP][0m [33m WARN[0m [2mhandlr::common::handler[0m[2m:[0m The desktop entry `emacs.desktop` is invalid: No such file or directory (os error 2)
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Expanding wildcards in mimeapps.list: false
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m New handlers for `text/markdown`: emacs.desktop;
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Finished adding handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/empty.md`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/markdown` in mimeapps.list Default Associations: emacs.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/markdown` in mimeapps.list Default Associations
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m No matching regex handlers found for `tests/assets/empty.txt`
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Configured handlers for `text/plain` in mimeapps.list Default Associations: nvim.desktop;
+[2m[TIMESTAMP][0m [34mDEBUG[0m [2mhandlr::apps::user[0m[2m:[0m Selector enabled: false, number of set handlers: 1
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::apps::user[0m[2m:[0m Not running selector, choosing first handler
+[2m[TIMESTAMP][0m [32m INFO[0m [2mhandlr::config::main_config[0m[2m:[0m Match found for `text/plain` in mimeapps.list Default Associations


### PR DESCRIPTION
Currently handlr only takes the most specific mimetype into account when opening files. This means handlr can't open a file, if a handler was only defined for a more general mimetype of a file. As a trivial example, if no handler was defined for opening a `text/markdown` file handlr will simply return an error, even if a handler for `text/plain` exists.
This PR changes the `get_handler_from_path` function to iteratively check all applicable mimetypes of a file until a valid handler is found. It uses a BFS-like manner to check mimetypes from most-specific to most-general.

This PR relies on the `get_parents_aliased` function from the `xdg-mime` crate, which is only available upstream but not in a release yet. Thus you might want to wait with merging this PR until `xdg-mime` had a new release to avoid building from the main branch of `xdg-mime` directly.