### PR TITLE
Properly detach graphical applications from terminal

### DIFF
--- a/src/common/desktop_entry.rs
+++ b/src/common/desktop_entry.rs
@@ -5,7 +5,7 @@ use crate::{
 use freedesktop_entry_parser::Entry;
 use itertools::Itertools;
 use mime::Mime;
-use std::{ffi::OsString, path::Path, process::Stdio, str::FromStr};
+use std::{ffi::OsString, os::unix::process::CommandExt, path::Path, process::Stdio, str::FromStr};
 use tracing::debug;
 
 /// Represents a desktop entry file for an application
@@ -69,7 +69,7 @@ impl DesktopEntry {
         if self.terminal && config.terminal_output {
             cmd.spawn()?.wait()?;
         } else {
-            cmd.stdout(Stdio::null()).stderr(Stdio::null()).spawn()?;
+            cmd.process_group(0).stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null()).spawn()?;
         }
 
         Ok(())


### PR DESCRIPTION
This PR ensures that graphical processes are entirely detached from the terminal session by redirecting `stdin` and putting them into their own process group. This means graphical applications are no longer dependant on the running terminal and are not killed when the terminal exits, as well as that the terminal is not kept active by a running application still reading from `stdin`. (The kitty terminal for example does not automatically close as long as an application still has an open file descriptor to it.)

This fix is especially important if handlr is used as the last executable in a terminal session and the terminal is closed as soon as handlr finishes. Currently this would prevent a graphical application from being started, as it is immediately killed by the closing terminal. (You can test this easily by running something like `xterm -e handlr launch application/pdf`, with Evince or similar set as the default handler for `application/pdf`. You will see that Evince is not started, as it is killed immediately.) This patch effectively behaves as if the command were launched with `setsid`, preventing the kill signal.